### PR TITLE
Add Sparkfun ESP32-C6 Thing Plus board definition

### DIFF
--- a/boards/sparkfun_esp32c6_thing_plus.json
+++ b/boards/sparkfun_esp32c6_thing_plus.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "core": "esp32",
+    "f_cpu": "160000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32c6",
+    "variant": "sparkfun_esp32c6_thing_plus",
+    "extra_flags": [
+        "-DARDUINO_ESP32C6_THING_PLUS",
+        "-DARDUINO_USB_CDC_ON_BOOT=1",
+        "-DARDUINO_USB_MODE=1"
+    ]
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "zigbee",
+    "thread"
+  ],
+  "debug": {
+    "openocd_target": "esp32c6.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Sparkfun ESP32-C6 Thing Plus",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.sparkfun.com/products/22924",
+  "vendor": "Sparkfun"
+}


### PR DESCRIPTION
## Description:
Add Sparkfun ESP32-C6 Thing Plus board definition

**Related issue (if applicable): https://github.com/platformio/platform-espressif32/pull/1370

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/develop/CONTRIBUTING.md).
