### PR TITLE
fix custom partiton table offset calculation

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -131,7 +131,7 @@ def _parse_partitions(env):
 
     result = []
     next_offset = 0
-    bound = int(board.get("upload.offset_address", "0x10000"), 16) # default 0x10000
+    app_offset = int(board.get("upload.offset_address", "0x10000"), 16) # default 0x10000
     with open(partitions_csv) as fp:
         for line in fp.readlines():
             line = line.strip()
@@ -140,23 +140,25 @@ def _parse_partitions(env):
             tokens = [t.strip() for t in line.split(",")]
             if len(tokens) < 5:
                 continue
+            bound = 0x10000 if tokens[1] in ("0", "app") else 4
+            calculated_offset = (next_offset + bound - 1) & ~(bound - 1)
             partition = {
                 "name": tokens[0],
                 "type": tokens[1],
                 "subtype": tokens[2],
-                "offset": tokens[3] or next_offset,
+                "offset": tokens[3] or calculated_offset,
                 "size": tokens[4],
                 "flags": tokens[5] if len(tokens) > 5 else None
             }
             result.append(partition)
             next_offset = _parse_size(partition["offset"])
             if (partition["subtype"] == "ota_0"):
-                bound = next_offset
-            next_offset = (next_offset + bound - 1) & ~(bound - 1)
+                app_offset = next_offset
+            next_offset = next_offset + _parse_size(partition["size"])
     # Configure application partition offset
-    env.Replace(ESP32_APP_OFFSET=str(hex(bound)))
+    env.Replace(ESP32_APP_OFFSET=str(hex(app_offset)))
     # Propagate application offset to debug configurations
-    env["INTEGRATION_EXTRA_DATA"].update({"application_offset": str(hex(bound))})
+    env["INTEGRATION_EXTRA_DATA"].update({"application_offset": str(hex(app_offset))})
     return result
 
 


### PR DESCRIPTION
## Description:
With a the following partition table it will flash the filesystem to 0x10000 instead of to 0x00d90000.

```csv
nvs,      data, nvs,     0x9000,  20K,
otadata,  data, ota,     0xe000,  8K,
app0,     app,  ota_0,   0x10000, 6400K,
app1,     app,  ota_1,   ,        6400K,
conf,     data, spiffs,  ,        1M,
spiffs,   data, spiffs,  ,        2432K,
coredump, data, coredump,,        64K,
```

Blank offset is supported as specified here <https://docs.espressif.com/projects/esp-idf/en/v5.1.5/esp32/api-guides/partition-tables.html#creating-custom-tables>

## Checklist:
  - [ x] The pull request is done against the latest develop branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [ x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/develop/CONTRIBUTING.md).
