### PR TITLE
Add SparkFun Qwiic Pocket board definition

### DIFF
--- a/boards/sparkfun_qwiic_pocket_esp32c6.json
+++ b/boards/sparkfun_qwiic_pocket_esp32c6.json
@@ -1,0 +1,30 @@
+{
+  "build": {
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_SFE_QWIIC_POCKET_ESP32C6",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "f_cpu": "160000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32c6",
+    "variant": "sparkfun_esp32c6_qwiic_pocket"
+  },
+  "connectivity": ["wifi", "bluetooth", "zigbee", "thread"],
+  "debug": {
+    "openocd_target": "esp32c6.cfg"
+  },
+  "frameworks": ["arduino", "espidf"],
+  "name": "SparkFun ESP32-C6 Qwiic Pocket",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.sparkfun.com/products/22925",
+  "vendor": "SparkFun"
+}

--- a/boards/sparkfun_qwiic_pocket_esp32c6.json
+++ b/boards/sparkfun_qwiic_pocket_esp32c6.json
@@ -12,11 +12,19 @@
     "mcu": "esp32c6",
     "variant": "sparkfun_esp32c6_qwiic_pocket"
   },
-  "connectivity": ["wifi", "bluetooth", "zigbee", "thread"],
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "zigbee",
+    "thread"
+  ],
   "debug": {
     "openocd_target": "esp32c6.cfg"
   },
-  "frameworks": ["arduino", "espidf"],
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
   "name": "SparkFun ESP32-C6 Qwiic Pocket",
   "upload": {
     "flash_size": "4MB",


### PR DESCRIPTION
## Description:

Add ESP32-C6-MINI SparkFun Qwiic Pocket board definition

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/develop/CONTRIBUTING.md).
