### PR TITLE
Add `sparkfun_esp32s3_thing_plus` board definition

### DIFF
--- a/boards/sparkfun_esp32s3_thing_plus.json
+++ b/boards/sparkfun_esp32s3_thing_plus.json
@@ -1,9 +1,5 @@
 {
   "build": {
-    "arduino":{
-      "ldscript": "esp32s3_out.ld",
-      "partitions": "default.csv"
-    },
     "core": "esp32",
     "extra_flags": [
       "-DARDUINO_ESP32S3_DEV",
@@ -15,7 +11,6 @@
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "qio",
-    "cdc_on_boot": 1,
     "hwids": [
       [
         "0x303A",

--- a/boards/sparkfun_esp32s3_thing_plus.json
+++ b/boards/sparkfun_esp32s3_thing_plus.json
@@ -1,0 +1,53 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_DEV",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "cdc_on_boot": 1,
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "sparkfun_esp32s3_thing_plus"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "SPARKFUN_ESP32S3_THING_PLUS",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.sparkfun.com/products/24408",
+  "vendor": "SparkFun"
+}


### PR DESCRIPTION
## Description:

Adds a board manifest for the Sparkfun Thing Plus ESP32s3. Credit to @Vigeant for this one.

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/develop/CONTRIBUTING.md).
