### PR TITLE
Add board Huidu HD-WF2

### DIFF
--- a/boards/huidu_hd_wf2.json
+++ b/boards/huidu_hd_wf2.json
@@ -1,0 +1,55 @@
+{
+  "build": {
+    "arduino": {
+      "partitions": "default_8MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_HUIDU_HD_WF2",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "wifiduino32s3"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Huidu HD-WF2",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.hdwell.com/Product/index46.html",
+  "vendor": "Huidu Tech",
+  "information_urls": [
+    "https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA/discussions/667",
+    "https://github.com/vortigont/FireLamp_JeeUI/wiki/Huidu-HD%E2%80%90WF2"
+  ]
+}


### PR DESCRIPTION
An ESP32-S3 board with HUB75 connectors to drive RGB panels
 - 8MiB SPI flash
 - 2xHUB75 connectors
 - [pinout](https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA/discussions/667)
 - Vendor link: https://www.hdwell.com/Product/index46.html

