### PR TITLE
adafruit_qualia_s3_rgb666 Partition CSV Name Fix

### DIFF
--- a/boards/adafruit_qualia_s3_rgb666.json
+++ b/boards/adafruit_qualia_s3_rgb666.json
@@ -1,7 +1,6 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_opi",
       "partitions": "tinyuf2-partitions-16MB.csv"
     },

--- a/boards/adafruit_qualia_s3_rgb666.json
+++ b/boards/adafruit_qualia_s3_rgb666.json
@@ -3,7 +3,7 @@
     "arduino":{
       "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_opi",
-      "partitions": "partitions-16MB-tinyuf2.csv"
+      "partitions": "tinyuf2-partitions-16MB.csv"
     },
     "core": "esp32",
     "extra_flags": [


### PR DESCRIPTION
## Description:

Fixes error during build:
```*** [.pio\build\touch-avionics\partitions.bin] Source `partitions-16MB-tinyuf2.csv' not found, needed by target `.pio\build\touch-avionics\partitions.bin'.```

Was tipped off by [this comment](https://github.com/pioarduino/platform-espressif32/issues/14#issuecomment-2259077973) that the naming structure might be incorrect, and that appears to have been the case! 

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla).