### PR TITLE
Fix the link to the CLA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,4 @@
   - [ ] The pull request is done against the latest develop branch
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
-  - [ ] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/develop/CONTRIBUTING.md).
+  - [ ] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/develop/CONTRIBUTING.md).
