### PR TITLE
Add WEMOS LOLIN S3 Mini Pro board

### DIFF
--- a/boards/lolin_s3_mini.json
+++ b/boards/lolin_s3_mini.json
@@ -1,18 +1,18 @@
 {
     "build": {
       "arduino": {
-        "ldscript": "esp32s3_out.ld",
         "memory_type": "qio_qspi"
       },
       "core": "esp32",
       "extra_flags": [
         "-DBOARD_HAS_PSRAM",
         "-DARDUINO_LOLIN_S3_MINI",
-        "-DARDUINO_USB_MODE=1"
+        "-DARDUINO_USB_CDC_ON_BOOT=1"
       ],
       "f_cpu": "240000000L",
       "f_flash": "80000000L",
       "flash_mode": "qio",
+      "psram_type" : "qio",
       "hwids": [
         [
           "0x303A",

--- a/boards/lolin_s3_mini_pro.json
+++ b/boards/lolin_s3_mini_pro.json
@@ -1,18 +1,18 @@
 {
     "build": {
       "arduino": {
-        "ldscript": "esp32s3_out.ld",
         "memory_type": "qio_qspi"
       },
       "core": "esp32",
       "extra_flags": [
         "-DBOARD_HAS_PSRAM",
-        "-DARDUINO_LOLIN_S3_MINI",
-        "-DARDUINO_USB_MODE=1"
+        "-DARDUINO_LOLIN_S3_MINI_PRO",
+        "-DARDUINO_USB_CDC_ON_BOOT=1"
       ],
       "f_cpu": "240000000L",
       "f_flash": "80000000L",
       "flash_mode": "qio",
+      "psram_type" : "qio",
       "hwids": [
         [
           "0x303A",

--- a/boards/lolin_s3_mini_pro.json
+++ b/boards/lolin_s3_mini_pro.json
@@ -1,0 +1,47 @@
+{
+    "build": {
+      "arduino": {
+        "ldscript": "esp32s3_out.ld",
+        "memory_type": "qio_qspi"
+      },
+      "core": "esp32",
+      "extra_flags": [
+        "-DBOARD_HAS_PSRAM",
+        "-DARDUINO_LOLIN_S3_MINI",
+        "-DARDUINO_USB_MODE=1"
+      ],
+      "f_cpu": "240000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "qio",
+      "hwids": [
+        [
+          "0x303A",
+          "0x8167"
+        ]
+      ],
+      "mcu": "esp32s3",
+      "variant": "lolin_s3_mini_pro"
+    },
+    "connectivity": [
+      "bluetooth",
+      "wifi"
+    ],
+    "debug": {
+      "openocd_target": "esp32s3.cfg"
+    },
+    "frameworks": [
+      "arduino",
+      "espidf"
+    ],
+    "name": "WEMOS LOLIN S3 Mini Pro",
+    "upload": {
+      "flash_size": "4MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 4194304,
+      "require_upload_port": true,
+      "speed": 460800
+    },
+    "url": "https://www.wemos.cc/en/latest/s3/index.html",
+    "vendor": "WEMOS"
+}
+  


### PR DESCRIPTION
## Description:

Adds the WEMOS LOLIN S3 Mini Pro board. Vendor board here: https://www.wemos.cc/en/latest/s3/s3_mini_pro.html

## Checklist:
  - [X] The pull request is done against the latest develop branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [X] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
