### PR TITLE
Update recommended Arduino Core for espidf-arduino-matter-light

### DIFF
--- a/examples/espidf-arduino-matter-light/README.md
+++ b/examples/espidf-arduino-matter-light/README.md
@@ -53,7 +53,7 @@ Holding the BOOT button pressed for more than 10 seconds and then releasing it w
 
 ## Building the Application using WiFi and Matter
 
-This example has been tested with Arduino Core 3.0.4. It should work with newer versions too.
+This example has been tested with Arduino Core 3.1.3 based on IDF 5.3.2.250210. It should work with newer versions too.
 
 There is a configuration file for these SoC: esp32s3, esp32c3, esp32c6.
 Those are the tested devices that have a WS2812 RGB LED and can run BLE, WiFi and Matter.

--- a/examples/espidf-arduino-matter-light/platformio.ini
+++ b/examples/espidf-arduino-matter-light/platformio.ini
@@ -20,6 +20,8 @@ monitor_speed = 115200
 
 
 [env:esp32s3]
+; Working with Arduino Core 3.1.3 based on IDF 5.3.2.250210
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13/platform-espressif32.zip
 board = esp32-s3-devkitc-1
 board_build.embed_txtfiles =
     managed_components/espressif__esp_insights/server_certs/https_server.crt
@@ -28,7 +30,8 @@ board_build.embed_txtfiles =
     managed_components/espressif__esp_rainmaker/server_certs/rmaker_ota_server.crt
 
 [env:esp32c6]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+; Working with Arduino Core 3.1.3 based on IDF 5.3.2.250210
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13/platform-espressif32.zip
 board = esp32-c6-devkitc-1
 board_build.embed_txtfiles =
     managed_components/espressif__esp_insights/server_certs/https_server.crt

--- a/examples/espidf-arduino-matter-light/platformio.ini
+++ b/examples/espidf-arduino-matter-light/platformio.ini
@@ -26,3 +26,12 @@ board_build.embed_txtfiles =
     managed_components/espressif__esp_rainmaker/server_certs/rmaker_mqtt_server.crt
     managed_components/espressif__esp_rainmaker/server_certs/rmaker_claim_service_server.crt
     managed_components/espressif__esp_rainmaker/server_certs/rmaker_ota_server.crt
+
+[env:esp32c6]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+board = esp32-c6-devkitc-1
+board_build.embed_txtfiles =
+    managed_components/espressif__esp_insights/server_certs/https_server.crt
+    managed_components/espressif__esp_rainmaker/server_certs/rmaker_mqtt_server.crt
+    managed_components/espressif__esp_rainmaker/server_certs/rmaker_claim_service_server.crt
+    managed_components/espressif__esp_rainmaker/server_certs/rmaker_ota_server.crt


### PR DESCRIPTION
## Description:

- Recommended Arduino Core 3.1.3 version for espidf-arduino-matter-light in README
- Add missing esp32c6 board in platformio.ini regading README

**Related issue (if applicable):**

## Checklist:
  - [X] The pull request is done against the latest develop branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [X] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
