### PR TITLE
fix(matter_idf_component): Update CMakeLists.txt to use C++ 2a

### DIFF
--- a/examples/espidf-arduino-matter-light/CMakeLists.txt
+++ b/examples/espidf-arduino-matter-light/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CONFIG_IDF_TARGET_ESP32C2)
     include(relinker)
 endif()
 
-idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++17;-Os;-DCHIP_HAVE_CONFIG_H" APPEND)
+idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++2a;-Os;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os" APPEND)
 # For RISCV chips, project_include.cmake sets -Wno-format, but does not clear various
 # flags that depend on -Wformat


### PR DESCRIPTION
## Description:

`std::to_underlying`  needs C++ 23
Changed C++ STDLIB to use version 2a.
