### PR TITLE
Add tl-install to install tools not in pio registry. Using for install of newer OpenOCD

### DIFF
--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -93,6 +93,7 @@ custom_component_remove     = espressif/esp_hosted
 [env:esp32-c6-devkitc-1]
 platform = espressif32
 framework = arduino
+build_type = debug
 board = esp32-c6-devkitc-1
 monitor_speed = 115200
 custom_component_remove = espressif/esp_hosted

--- a/monitor/filter_exception_decoder.py
+++ b/monitor/filter_exception_decoder.py
@@ -32,7 +32,7 @@ IS_WINDOWS = sys.platform.startswith("win")
 class Esp32ExceptionDecoder(DeviceMonitorFilterBase):
     NAME = "esp32_exception_decoder"
 
-    ADDR_PATTERN = re.compile(r"((?:0x[0-9a-fA-F]{8}[: ]?)+)\s?$")
+    ADDR_PATTERN = re.compile(r"((?:0x[0-9a-fA-F]{8}[: ]?)+)")
     ADDR_SPLIT = re.compile(r"[ :]")
     PREFIX_RE = re.compile(r"^ *")
 

--- a/platform.json
+++ b/platform.json
@@ -101,11 +101,17 @@
       "owner": "platformio",
       "version": "~1.11.0"
     },
-    "tool-openocd-esp32": {
-      "type": "debugger",
+    "install-openocd-esp32": {
+      "type": "tool",
       "optional": false,
       "owner": "pioarduino",
       "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/openocd-v0.12.0-esp32-20250226.zip"
+    },
+    "tool-openocd-esp32": {
+      "type": "debugger",
+      "optional": true,
+      "owner": "pioarduino",
+      "version": ""
     },
     "tool-mklittlefs": {
       "type": "uploader",

--- a/platform.json
+++ b/platform.json
@@ -101,17 +101,11 @@
       "owner": "platformio",
       "version": "~1.11.0"
     },
-    "install-openocd-esp32": {
-      "type": "tool",
-      "optional": false,
-      "owner": "pioarduino",
-      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/openocd-v0.12.0-esp32-20250226.zip"
-    },
     "tool-openocd-esp32": {
       "type": "debugger",
       "optional": true,
       "owner": "pioarduino",
-      "version": ""
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/openocd-v0.12.0-esp32-20250226.zip"
     },
     "tool-mklittlefs": {
       "type": "uploader",

--- a/platform.json
+++ b/platform.json
@@ -6,13 +6,13 @@
   "license": "Apache-2.0",
   "keywords": [
     "dev-platform",
-    "Wi-Fi",
+    "WiFi",
     "Bluetooth",
     "Xtensa",
     "RISC-V"
   ],
   "engines": {
-    "platformio": ">=6.1.16"
+    "platformio": ">=6.1.18"
   },
   "repository": {
     "type": "git",
@@ -85,8 +85,15 @@
     },
     "tool-esptoolpy": {
       "type": "uploader",
+      "optional": false,
       "owner": "pioarduino",
       "version": "https://github.com/pioarduino/esptool/releases/download/v4.8.9/esptool.zip"
+    },
+    "tl-install": {
+      "type": "tool",
+      "optional": false,
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/esp_install/releases/download/v5.0.0/esp_install-v5.0.0.zip"
     },
     "tool-dfuutil-arduino": {
       "type": "uploader",
@@ -96,12 +103,13 @@
     },
     "tool-openocd-esp32": {
       "type": "debugger",
-      "optional": true,
-      "owner": "platformio",
-      "version": "~2.1100.0"
+      "optional": false,
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/openocd-v0.12.0-esp32-20250226.zip"
     },
     "tool-mklittlefs": {
       "type": "uploader",
+      "optional": true,
       "owner": "tasmota",
       "version": "^3.2.0"
     },
@@ -118,34 +126,46 @@
       "version": "~2.230.0"
     },
     "tool-cppcheck": {
+      "type": "tool",
       "optional": true,
       "owner": "platformio",
       "version": "~1.21100"
     },
     "tool-clangtidy": {
+      "type": "tool",
       "optional": true,
       "owner": "platformio",
       "version": "^1.190100.0"
     },
     "tool-pvs-studio": {
+      "type": "tool",
       "optional": true,
       "owner": "platformio",
       "version": "^7.18.59866"
     },
     "tool-cmake": {
+      "type": "tool",
       "optional": true,
       "owner": "platformio",
       "version": "~3.30.2"
     },
-     "tool-esp-rom-elfs": {
-       "optional": true,
-       "owner": "platformio",
-       "version": "0.0.1+20241011"
+    "tool-esp-rom-elfs": {
+      "type": "tool",
+      "optional": true,
+      "owner": "platformio",
+      "version": "0.0.1+20241011"
     },
     "tool-ninja": {
+      "type": "tool",
       "optional": true,
       "owner": "platformio",
       "version": "^1.7.0"
+    },
+    "tool-scons": {
+      "type": "tool",
+      "optional": true,
+      "owner": "platformio",
+      "version": "~4.40801.0"
     }
   }
 }

--- a/platform.py
+++ b/platform.py
@@ -74,7 +74,7 @@ class Espressif32Platform(PlatformBase):
                     if not os.path.exists(join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json")):
                         shutil.copyfile(TOOL_PACKAGE_PATH, join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))
                     self.packages.pop(TOOL, None)
-                    if os.path.exists(TOOL_PATH,) and os.path.isdir(TOOL_PATH):
+                    if os.path.exists(TOOL_PATH) and os.path.isdir(TOOL_PATH):
                         try:
                             shutil.rmtree(TOOL_PATH)
                         except Exception as e:

--- a/platform.py
+++ b/platform.py
@@ -57,7 +57,7 @@ def install_tool(TOOL):
             sys.stderr.write("Error: Couldn't execute 'idf_tools.py install'\n")
         else:
             tl_path = "file://" + join(TOOLS_PATH_DEFAULT, "tools", TOOL)
-            if not bool(os.path.exists(join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))):
+            if not os.path.exists(join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json")):
                 shutil.copyfile(TOOLS_PACK_PATH, join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))
             pm.install(tl_path)
     return

--- a/platform.py
+++ b/platform.py
@@ -13,13 +13,15 @@
 # limitations under the License.
 
 import os
-import urllib
+import subprocess
 import sys
-import json
-import re
-import requests
+import shutil
+from os.path import join
 
 from platformio.public import PlatformBase, to_unix_path
+from platformio.proc import get_pythonexe_path
+from platformio.project.config import ProjectConfig
+from platformio.package.manager.tool import ToolPackageManager
 
 
 IS_WINDOWS = sys.platform.startswith("win")
@@ -28,6 +30,36 @@ IS_WINDOWS = sys.platform.startswith("win")
 # needs platformio core >= 6.1.16b2 or pioarduino core 6.1.16+test
 if IS_WINDOWS:
     os.environ["PLATFORMIO_SYSTEM_TYPE"] = "windows_amd64"
+
+python_exe = get_pythonexe_path()
+pm = ToolPackageManager()
+
+def install_tool(TOOL):
+    TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".platformio")
+    IDF_TOOLS = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tl-install", "tools", "idf_tools.py")
+    TOOLS_JSON_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "tools.json")
+    TOOLS_PACK_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "package.json")
+    IDF_TOOLS_CMD = (
+        python_exe,
+        IDF_TOOLS,
+        "--quiet",
+        "--non-interactive",
+        "--tools-json",
+        TOOLS_JSON_PATH,
+        "install"
+    )
+
+    tl_flag = bool(os.path.exists(IDF_TOOLS))
+    json_flag = bool(os.path.exists(TOOLS_JSON_PATH))
+    if tl_flag and json_flag:
+        rc = subprocess.call(IDF_TOOLS_CMD)
+        if rc != 0:
+            sys.stderr.write("Error: Couldn't execute 'idf_tools.py install'\n")
+        else:
+            tl_path = "file://" + join(TOOLS_PATH_DEFAULT, "tools", TOOL)
+            shutil.copyfile(TOOLS_PACK_PATH, join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))
+            pm.install(tl_path)
+    return
 
 
 class Espressif32Platform(PlatformBase):
@@ -43,7 +75,12 @@ class Espressif32Platform(PlatformBase):
         core_variant_build = (''.join(variables.get("build_flags", []))).replace("-D", " ")
         frameworks = variables.get("pioframework", [])
 
-        if "arduino" in frameworks:
+        # Installer only needed for setup, deactivate
+        self.packages["tl-install"]["optional"] = True
+        # Installed not from pio registry, deactivate until needed
+        self.packages["tool-openocd-esp32"]["optional"] = True
+
+        if "arduino" in frameworks and variables.get("custom_sdkconfig") is None and len(str(board_sdkconfig)) < 3:
             self.packages["framework-arduinoespressif32"]["optional"] = False
             self.packages["framework-arduinoespressif32-libs"]["optional"] = False
             # use matching espressif Arduino libs
@@ -93,21 +130,20 @@ class Espressif32Platform(PlatformBase):
         # Starting from v12, Espressif's toolchains are shipped without
         # bundled GDB. Instead, it's distributed as separate packages for Xtensa
         # and RISC-V targets.
-        for gdb_package in ("tool-xtensa-esp-elf-gdb", "tool-riscv32-esp-elf-gdb"):
-            self.packages[gdb_package]["optional"] = False
-            # if IS_WINDOWS:
-                # Note: On Windows GDB v12 is not able to
-                # launch a GDB server in pipe mode while v11 works fine
-                # self.packages[gdb_package]["version"] = "~11.2.0"
+        if (variables.get("build_type") or "debug" in "".join(targets)) or variables.get("upload_protocol"):
+            for gdb_package in ("tool-xtensa-esp-elf-gdb", "tool-riscv32-esp-elf-gdb"):
+                self.packages[gdb_package]["optional"] = False
+            install_tool("tool-openocd-esp32")
+            self.packages["tool-openocd-esp32"]["optional"] = False
 
         # Common packages for IDF and mixed Arduino+IDF projects
         if "espidf" in frameworks:
             self.packages["toolchain-esp32ulp"]["optional"] = False
             for p in self.packages:
                 if p in (
-                    "tool-scons",
                     "tool-cmake",
                     "tool-ninja",
+                    "tool-scons",
                     "tool-esp-rom-elfs",
                  ):
                     self.packages[p]["optional"] = False
@@ -119,8 +155,8 @@ class Espressif32Platform(PlatformBase):
         else:
             self.packages.pop("toolchain-xtensa-esp-elf", None)
 
-        if mcu in ("esp32s2", "esp32s3", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32p4"):
-            if mcu in ("esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32p4"):
+        if mcu in ("esp32s2", "esp32s3", "esp32c2", "esp32c3", "esp32c5", "esp32c6", "esp32h2", "esp32p4"):
+            if mcu in ("esp32c2", "esp32c3", "esp32c5", "esp32c6", "esp32h2", "esp32p4"):
                 self.packages.pop("toolchain-esp32ulp", None)
             # RISC-V based toolchain for ESP32C3, ESP32C6 ESP32S2, ESP32S3 ULP
             self.packages["toolchain-riscv32-esp"]["optional"] = False

--- a/platform.py
+++ b/platform.py
@@ -57,7 +57,8 @@ def install_tool(TOOL):
             sys.stderr.write("Error: Couldn't execute 'idf_tools.py install'\n")
         else:
             tl_path = "file://" + join(TOOLS_PATH_DEFAULT, "tools", TOOL)
-            shutil.copyfile(TOOLS_PACK_PATH, join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))
+            if not bool(os.path.exists(join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))):
+                shutil.copyfile(TOOLS_PACK_PATH, join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))
             pm.install(tl_path)
     return
 

--- a/platform.py
+++ b/platform.py
@@ -80,7 +80,7 @@ class Espressif32Platform(PlatformBase):
         # Installed not from pio registry, deactivate until needed
         self.packages["tool-openocd-esp32"]["optional"] = True
 
-        if "arduino" in frameworks and variables.get("custom_sdkconfig") is None and len(str(board_sdkconfig)) < 3:
+        if "arduino" in frameworks:
             self.packages["framework-arduinoespressif32"]["optional"] = False
             self.packages["framework-arduinoespressif32-libs"]["optional"] = False
             # use matching espressif Arduino libs

--- a/platform.py
+++ b/platform.py
@@ -76,8 +76,9 @@ class Espressif32Platform(PlatformBase):
         core_variant_build = (''.join(variables.get("build_flags", []))).replace("-D", " ")
         frameworks = variables.get("pioframework", [])
 
-        # Installer only needed for setup, deactivate
-        self.packages["tl-install"]["optional"] = True
+        # Installer only needed for setup, deactivate when installed
+        if bool(os.path.exists(os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tl-install", "tools", "idf_tools.py"))):
+            self.packages["tl-install"]["optional"] = True
         # Installed not from pio registry, deactivate until needed
         self.packages["tool-openocd-esp32"]["optional"] = True
 


### PR DESCRIPTION
## Description:

Currently it is only possible to install tools and toolchains from Platformio registry.
The PR adds the option to install tools from a github repo release section. To make this possible a tarball needs to be created which has a valid platformio `package.json` (not platform specific!) and a manifest json with name `tools.json` in it. The syntax for the entrys in `tools.json` is explained [here](https://github.com/pioarduino/esp_install/blob/empty_tools/tools/tools_schema.json) The link to the tarball is added in the `platform.json` under the tool "version" entry. Make the tool option entry "optional" = `True`
For installing and activating the tool via the alternative installer it simply needs to be called like this `install_tool("tool-openocd-esp32")` in platform.py. Now the tool `tool-openocd-esp32` will be installed (matching to the OS) from the espressif github OpenOCD repo and can be used like installed from Platformio registry.

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package metadata and tool management for improved compatibility and maintenance, including new tool additions, ownership changes, and version updates.
  - Adjusted configuration to enable debug build type for specific ESP32 environment.
  - Improved handling of tool installation and activation, with refined package enabling logic and expanded MCU support.
- **Bug Fixes**
  - Enhanced address matching in exception decoder to work in more scenarios by updating the pattern matching logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->