### PR TITLE
Remove all dependencies to Platformio registry

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -15,6 +15,9 @@ jobs:
         os: [ubuntu-24.04, macos-15]
         example:
           - "examples/arduino-wifiscan"
+          - "examples/espidf-ulp"
+          - "examples/espidf-ulp-riscv"
+          - "examples/espidf-ulp-lp"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,9 +12,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15]
+        os: [ubuntu-24.04, windows-latest, macos-15]
         example:
+          - "examples/arduino-blink"
+          - "examples/arduino-rmt-blink"
+          - "examples/arduino-usb-keyboard"
           - "examples/arduino-wifiscan"
+          - "examples/arduino-zigbee-light"
+          - "examples/arduino-zigbee-switch"
+          - "examples/tasmota"
+          - "examples/espidf-arduino-h2zero-BLE_scan"
+          - "examples/espidf-arduino-matter-light"
+          - "examples/arduino-matter-light"
+          - "examples/espidf-arduino-blink"
+          - "examples/espidf-arduino-littlefs"
+          - "examples/espidf-blink"
+          - "examples/espidf-coap-server"
+          - "examples/espidf-exceptions"
+          - "examples/espidf-hello-world"
+          - "examples/espidf-http-request"
+          - "examples/espidf-peripherals-uart"
+          - "examples/espidf-peripherals-usb"
+          - "examples/espidf-storage-sdcard"
           - "examples/espidf-ulp"
           - "examples/espidf-ulp-riscv"
           - "examples/espidf-ulp-lp"

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,31 +12,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-latest, macos-15]
+        os: [ubuntu-24.04, macos-15]
         example:
-          - "examples/arduino-blink"
-          - "examples/arduino-rmt-blink"
-          - "examples/arduino-usb-keyboard"
           - "examples/arduino-wifiscan"
-          - "examples/arduino-zigbee-light"
-          - "examples/arduino-zigbee-switch"
-          - "examples/tasmota"
-          - "examples/espidf-arduino-h2zero-BLE_scan"
-          - "examples/espidf-arduino-matter-light"
-          - "examples/arduino-matter-light"
-          - "examples/espidf-arduino-blink"
-          - "examples/espidf-arduino-littlefs"
-          - "examples/espidf-blink"
-          - "examples/espidf-coap-server"
-          - "examples/espidf-exceptions"
-          - "examples/espidf-hello-world"
-          - "examples/espidf-http-request"
-          - "examples/espidf-peripherals-uart"
-          - "examples/espidf-peripherals-usb"
-          - "examples/espidf-storage-sdcard"
-          - "examples/espidf-ulp"
-          - "examples/espidf-ulp-riscv"
-          - "examples/espidf-ulp-lp"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/examples/arduino-wifiscan/platformio.ini
+++ b/examples/arduino-wifiscan/platformio.ini
@@ -29,6 +29,14 @@ upload_protocol = esp-builtin
 monitor_speed = 115200
 check_tool = cppcheck
 
+[env:esp32-c2]
+ platform = espressif32
+ framework = arduino
+ board = esp32-c2-devkitm-1
+ upload_protocol = esp-prog
+ monitor_speed = 115200
+ check_tool = clangtidy
+
 [env:esp32-c3]
 platform = espressif32
 framework = arduino

--- a/examples/arduino-wifiscan/platformio.ini
+++ b/examples/arduino-wifiscan/platformio.ini
@@ -20,14 +20,6 @@ custom_component_remove =
                           espressif/esp-zboss-lib
                           espressif/esp-zigbee-lib
                           espressif/esp_rainmaker
-                          espressif/rmaker_common
-                          espressif/esp_insights
-                          espressif/esp_diag_data_store
-                          espressif/esp_diagnostics
-                          espressif/cbor
-                          espressif/qrcode
-                          espressif/esp-sr
-                          espressif/libsodium
+                          espressif/esp-sr                      
                           espressif/esp-modbus
-                          chmorgan/esp-libhelix-mp3
                           espressif/esp32-camera

--- a/examples/arduino-wifiscan/platformio.ini
+++ b/examples/arduino-wifiscan/platformio.ini
@@ -7,6 +7,14 @@
 ; Please visit documentation for the other options and examples
 ; http://docs.platformio.org/page/projectconf.html
 
+[env:esp32-s3]
+platform = espressif32
+framework = arduino
+board = esp32-s3-devkitc-1
+upload_protocol = esp-builtin
+monitor_speed = 115200
+check_tool = cppcheck
+
 [env:esp32-c2]
 platform = espressif32
 framework = arduino

--- a/examples/arduino-wifiscan/platformio.ini
+++ b/examples/arduino-wifiscan/platformio.ini
@@ -7,28 +7,6 @@
 ; Please visit documentation for the other options and examples
 ; http://docs.platformio.org/page/projectconf.html
 
-[env:esp-wrover-kit]
-platform = espressif32
-framework = arduino
-board = esp-wrover-kit
-monitor_speed = 115200
-
-[env:esp32-s2]
-platform = espressif32
-framework = arduino
-board = esp32-s2-saola-1
-upload_protocol = esp-prog
-monitor_speed = 115200
-check_tool = clangtidy
-
-[env:esp32-s3]
-platform = espressif32
-framework = arduino
-board = esp32-s3-devkitc-1
-upload_protocol = esp-builtin
-monitor_speed = 115200
-check_tool = cppcheck
-
 [env:esp32-c2]
 platform = espressif32
 framework = arduino
@@ -36,18 +14,20 @@ board = esp32-c2-devkitm-1
 upload_protocol = esp-prog
 monitor_speed = 115200
 check_tool = clangtidy
-
-[env:esp32-c3]
-platform = espressif32
-framework = arduino
-board = esp32-c3-devkitm-1
-upload_protocol = esp-builtin
-monitor_speed = 115200
-check_tool = pvs-studio
-
-[env:esp32-c6]
-platform = espressif32
-framework = arduino
-board = esp32-c6-devkitm-1
-upload_protocol = esp-builtin
-monitor_speed = 115200
+custom_component_remove =
+                          espressif/esp-dsp
+                          espressif/network_provisioning
+                          espressif/esp-zboss-lib
+                          espressif/esp-zigbee-lib
+                          espressif/esp_rainmaker
+                          espressif/rmaker_common
+                          espressif/esp_insights
+                          espressif/esp_diag_data_store
+                          espressif/esp_diagnostics
+                          espressif/cbor
+                          espressif/qrcode
+                          espressif/esp-sr
+                          espressif/libsodium
+                          espressif/esp-modbus
+                          chmorgan/esp-libhelix-mp3
+                          espressif/esp32-camera

--- a/examples/arduino-wifiscan/platformio.ini
+++ b/examples/arduino-wifiscan/platformio.ini
@@ -7,6 +7,20 @@
 ; Please visit documentation for the other options and examples
 ; http://docs.platformio.org/page/projectconf.html
 
+[env:esp-wrover-kit]
+platform = espressif32
+framework = arduino
+board = esp-wrover-kit
+monitor_speed = 115200
+
+[env:esp32-s2]
+platform = espressif32
+framework = arduino
+board = esp32-s2-saola-1
+upload_protocol = esp-prog
+monitor_speed = 115200
+check_tool = clangtidy
+
 [env:esp32-s3]
 platform = espressif32
 framework = arduino
@@ -31,3 +45,18 @@ custom_component_remove =
                           espressif/esp-sr                      
                           espressif/esp-modbus
                           espressif/esp32-camera
+
+[env:esp32-c3]
+platform = espressif32
+framework = arduino
+board = esp32-c3-devkitm-1
+upload_protocol = esp-builtin
+monitor_speed = 115200
+check_tool = pvs-studio
+
+[env:esp32-c6]
+platform = espressif32
+framework = arduino
+board = esp32-c6-devkitm-1
+upload_protocol = esp-builtin
+monitor_speed = 115200

--- a/examples/arduino-wifiscan/platformio.ini
+++ b/examples/arduino-wifiscan/platformio.ini
@@ -30,12 +30,12 @@ monitor_speed = 115200
 check_tool = cppcheck
 
 [env:esp32-c2]
- platform = espressif32
- framework = arduino
- board = esp32-c2-devkitm-1
- upload_protocol = esp-prog
- monitor_speed = 115200
- check_tool = clangtidy
+platform = espressif32
+framework = arduino
+board = esp32-c2-devkitm-1
+upload_protocol = esp-prog
+monitor_speed = 115200
+check_tool = clangtidy
 
 [env:esp32-c3]
 platform = espressif32

--- a/platform.json
+++ b/platform.json
@@ -164,8 +164,8 @@
     "tool-scons": {
       "type": "tool",
       "optional": true,
-      "owner": "platformio",
-      "version": "~4.40801.0"
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/scons/releases/download/4.8.1/scons-local-4.8.1.tar.gz"
     }
   }
 }

--- a/platform.json
+++ b/platform.json
@@ -146,14 +146,14 @@
     "tool-cmake": {
       "type": "tool",
       "optional": true,
-      "owner": "platformio",
-      "version": "~3.30.2"
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/cmake-3.30.2.zip"
     },
     "tool-esp-rom-elfs": {
       "type": "tool",
       "optional": true,
-      "owner": "platformio",
-      "version": "0.0.1+20241011"
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/esp-rom-elfs-20241011.zip"
     },
     "tool-ninja": {
       "type": "tool",

--- a/platform.json
+++ b/platform.json
@@ -165,7 +165,7 @@
       "type": "tool",
       "optional": true,
       "owner": "pioarduino",
-      "version": "https://github.com/pioarduino/scons/releases/download/4.8.1/scons-local-4.8.1.tar.gz"
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/scons-4.8.1.zip"
     }
   }
 }

--- a/platform.json
+++ b/platform.json
@@ -158,8 +158,8 @@
     "tool-ninja": {
       "type": "tool",
       "optional": true,
-      "owner": "platformio",
-      "version": "^1.7.0"
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/ninja-1.10.2.zip"
     },
     "tool-scons": {
       "type": "tool",

--- a/platform.json
+++ b/platform.json
@@ -99,7 +99,7 @@
       "type": "uploader",
       "optional": true,
       "owner": "pioarduino",
-      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/dfuutil-1.11.0.zip"
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/dfuutil-arduino-v1.11.0.zip"
     },
     "tool-openocd-esp32": {
       "type": "debugger",

--- a/platform.json
+++ b/platform.json
@@ -98,8 +98,8 @@
     "tool-dfuutil-arduino": {
       "type": "uploader",
       "optional": true,
-      "owner": "platformio",
-      "version": "~1.11.0"
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/dfuutil-1.11.0.zip"
     },
     "tool-openocd-esp32": {
       "type": "debugger",
@@ -110,38 +110,38 @@
     "tool-mklittlefs": {
       "type": "uploader",
       "optional": true,
-      "owner": "tasmota",
-      "version": "^3.2.0"
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/mklittlefs-3.2.0.zip"
     },
     "tool-mkfatfs": {
       "type": "uploader",
       "optional": true,
-      "owner": "platformio",
-      "version": "~2.0.0"
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/mkfatfs-v2.0.1.zip"
     },
     "tool-mkspiffs": {
       "type": "uploader",
       "optional": true,
-      "owner": "platformio",
-      "version": "~2.230.0"
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/mkspiffs-v2.230.0.zip"
     },
     "tool-cppcheck": {
       "type": "tool",
       "optional": true,
-      "owner": "platformio",
-      "version": "~1.21100"
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/cppcheck-v2.11.0-230717.zip"
     },
     "tool-clangtidy": {
       "type": "tool",
       "optional": true,
-      "owner": "platformio",
-      "version": "^1.190100.0"
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/clangtidy-v18.1.1.zip"
     },
     "tool-pvs-studio": {
       "type": "tool",
       "optional": true,
-      "owner": "platformio",
-      "version": "^7.18.0"
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/pvs-studio-v7.18.zip"
     },
     "tool-cmake": {
       "type": "tool",

--- a/platform.json
+++ b/platform.json
@@ -56,14 +56,14 @@
     "toolchain-xtensa-esp-elf": {
       "type": "toolchain",
       "optional": true,
-      "owner": "platformio",
-      "version": "14.2.0+20241119"
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/xtensa-esp-elf-14.2.0_20241119.zip"
     },
     "toolchain-riscv32-esp": {
       "type": "toolchain",
       "optional": true,
-      "owner": "platformio",
-      "version": "14.2.0+20241119"
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/riscv32-esp-elf-14.2.0_20241119.zip"
     },
     "toolchain-esp32ulp": {
       "type": "toolchain",

--- a/platform.json
+++ b/platform.json
@@ -68,8 +68,8 @@
     "toolchain-esp32ulp": {
       "type": "toolchain",
       "optional": true,
-      "owner": "platformio",
-      "version": "~1.23800.0"
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/esp32ulp-elf-2.38_20240113.zip"
     },
       "tool-xtensa-esp-elf-gdb": {
       "type": "debugger",

--- a/platform.py
+++ b/platform.py
@@ -129,7 +129,7 @@ class Espressif32Platform(PlatformBase):
             if mcu in supported_mcus:
                 # Set mandatory toolchains
                 for toolchain in toolchain_data["toolchains"]:
-                    self.packages[toolchain]["optional"] = False
+                    install_tool(toolchain)
 
                 # Set ULP toolchain if applicable
                 ulp_toolchain = toolchain_data.get("ulp_toolchain")

--- a/platform.py
+++ b/platform.py
@@ -164,28 +164,28 @@ class Espressif32Platform(PlatformBase):
             for package in CHECK_PACKAGES:
                 for check_tool in variables.get("check_tool", ""):
                     if check_tool in package:
-                        self.packages[package]["optional"] = False
+                        install_tool(package)
 
         if "buildfs" in targets:
             filesystem = variables.get("board_build.filesystem", "littlefs")
             if filesystem == "littlefs":
-                self.packages["tool-mklittlefs"]["optional"] = False
+                install_tool("tool-mklittlefs")
             elif filesystem == "fatfs":
-                self.packages["tool-mkfatfs"]["optional"] = False
+                install_tool("tool-mkfatfs")
             else:
-                self.packages["tool-mkspiffs"]["optional"] = False
+                install_tool("tool-mkspiffs")
 
         if "downloadfs" in targets:
             filesystem = variables.get("board_build.filesystem", "littlefs")
             if filesystem == "littlefs":
                 # Use Tasmota mklittlefs v4.0.0 to unpack, older version is incompatible
-                self.packages["tool-mklittlefs"]["version"] = "~4.0.0"
+                self.packages["tool-mklittlefs"]["version"] = "https://github.com/pioarduino/registry/releases/download/0.0.1/mklittlefs-4.0.0.zip"
+                self.packages["tool-mklittlefs"]["optional"] = False
+                install_tool("tool-mklittlefs")
 
         # Currently only Arduino Nano ESP32 uses the dfuutil tool as uploader
         if variables.get("board") == "arduino_nano_esp32":
-            self.packages["tool-dfuutil-arduino"]["optional"] = False
-        else:
-            del self.packages["tool-dfuutil-arduino"]
+            install_tool("tool-dfuutil-arduino")
 
         return super().configure_default_packages(variables, targets)
 

--- a/platform.py
+++ b/platform.py
@@ -152,7 +152,7 @@ class Espressif32Platform(PlatformBase):
         ]
         if "espidf" in frameworks:
             for package in COMMON_IDF_PACKAGES:
-                self.packages[package]["optional"] = False
+                install_tool(package)
 
         CHECK_PACKAGES = [
             "tool-cppcheck",

--- a/platform.py
+++ b/platform.py
@@ -135,7 +135,7 @@ class Espressif32Platform(PlatformBase):
                 ulp_toolchain = toolchain_data.get("ulp_toolchain")
                 if ulp_toolchain and os.path.isdir("ulp"):
                     for toolchain in ulp_toolchain:
-                        self.packages[toolchain]["optional"] = False
+                        install_tool(toolchain)
                 # Install debug tools if conditions match
                 if (variables.get("build_type") or "debug" in "".join(targets)) or variables.get("upload_protocol"):
                     for debug_tool in toolchain_data["debug_tools"]:


### PR DESCRIPTION
## Description:

The PR removes the dependencies from Platformio registry. All tools and toolchains are installed now from pioarduino or espressif github repos.

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the ESP32-C2 DevKitM-1 board in the Arduino WiFi scan example, including a dedicated environment configuration.

- **Chores**
  - Updated toolchain and utility package sources to use direct download links from a new owner, ensuring more precise version control.
  - Improved internal tool installation logic for better package management during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->