### PR TITLE
Update to esptool.py v5.0.0-dev

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -89,6 +89,7 @@ def install_standard_python_deps():
         "wheel": ">=0.35.1",
         "rich-click": ">=1.8.6",
         "PyYAML": ">=6.0.2",
+        "intelhex": ">=2.3.0",
         "rich": ">=14.0.0",
         "esp-idf-size": ">=1.6.1"
     }

--- a/builder/main.py
+++ b/builder/main.py
@@ -270,7 +270,7 @@ env.Replace(
         "--chip", mcu,
         "--port", '"$UPLOAD_PORT"'
     ],
-    ERASECMD='"$PYTHONEXE" "$OBJCOPY" $ERASEFLAGS erase_flash',
+    ERASECMD='"$PYTHONEXE" "$OBJCOPY" $ERASEFLAGS erase-flash',
 
     # mkspiffs package contains two different binaries for IDF and Arduino
     MKFSTOOL="mk%s" % filesystem
@@ -323,9 +323,9 @@ env.Append(
             action=env.VerboseAction(" ".join([
                 '"$PYTHONEXE" "$OBJCOPY"',
                 "--chip", mcu, "elf2image",
-                "--flash_mode", "${__get_board_flash_mode(__env__)}",
-                "--flash_freq", "${__get_board_f_image(__env__)}",
-                "--flash_size", board.get("upload.flash_size", "4MB"),
+                "--flash-mode", "${__get_board_flash_mode(__env__)}",
+                "--flash-freq", "${__get_board_f_image(__env__)}",
+                "--flash-size", board.get("upload.flash_size", "4MB"),
                 "-o", "$TARGET", "$SOURCES"
             ]), "Building $TARGET"),
             suffix=".bin"
@@ -479,12 +479,12 @@ elif upload_protocol == "esptool":
             "--chip", mcu,
             "--port", '"$UPLOAD_PORT"',
             "--baud", "$UPLOAD_SPEED",
-            "--before", board.get("upload.before_reset", "default_reset"),
-            "--after", board.get("upload.after_reset", "hard_reset"),
-            "write_flash", "-z",
-            "--flash_mode", "${__get_board_flash_mode(__env__)}",
-            "--flash_freq", "${__get_board_f_image(__env__)}",
-            "--flash_size", "detect"
+            "--before", board.get("upload.before_reset", "default-reset"),
+            "--after", board.get("upload.after_reset", "hard-reset"),
+            "write-flash", "-z",
+            "--flash-mode", "${__get_board_flash_mode(__env__)}",
+            "--flash-freq", "${__get_board_f_image(__env__)}",
+            "--flash-size", "detect"
         ],
         UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS $ESP32_APP_OFFSET $SOURCE'
     )
@@ -497,12 +497,12 @@ elif upload_protocol == "esptool":
                 "--chip", mcu,
                 "--port", '"$UPLOAD_PORT"',
                 "--baud", "$UPLOAD_SPEED",
-                "--before", board.get("upload.before_reset", "default_reset"),
-                "--after", board.get("upload.after_reset", "hard_reset"),
-                "write_flash", "-z",
-                "--flash_mode", "${__get_board_flash_mode(__env__)}",
-                "--flash_freq", "${__get_board_f_image(__env__)}",
-                "--flash_size", "detect",
+                "--before", board.get("upload.before_reset", "default-reset"),
+                "--after", board.get("upload.after_reset", "hard-reset"),
+                "write-flash", "-z",
+                "--flash-mode", "${__get_board_flash_mode(__env__)}",
+                "--flash-freq", "${__get_board_f_image(__env__)}",
+                "--flash-size", "detect",
                 "$FS_START"
             ],
             UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS $SOURCE',

--- a/platform.json
+++ b/platform.json
@@ -92,7 +92,7 @@
       "type": "uploader",
       "optional": false,
       "owner": "pioarduino",
-      "version": "https://github.com/pioarduino/esptool/releases/download/v4.8.11/esptool.zip"
+      "version": "https://github.com/pioarduino/esptool/releases/download/v5.0.0-dev/esptool.zip"
     },
     "tl-install": {
       "type": "tool",


### PR DESCRIPTION
## Description:

a lot of changes and fixes have been done in esptool.py. Especially C5 and P4

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of the esptool uploader tool to v5.0.0-dev.
  - Standardized command-line arguments for esptool.py to use hyphen-separated options for improved consistency.
  - Added a new Python package dependency, "intelhex", for the ESP-IDF framework environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->