### PR TITLE
Try to fix issues caused from old Platformio leftovers in `.platformio/packages` 

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -323,7 +323,8 @@ class Espressif32Platform(PlatformBase):
         tool_base_name = os.path.basename(paths['tool_path'])
         packages_dir = os.path.dirname(paths['tool_path'])
     
-        # Remove similar directories with version suffixes FIRST (e.g., xtensa.12232)
+        # Remove similar directories with version suffixes FIRST (e.g., xtensa@src, xtensa.12232)
+        safe_remove_directory_pattern(packages_dir, f"{tool_base_name}@*")
         safe_remove_directory_pattern(packages_dir, f"{tool_base_name}.*")
     
         # Then remove the main tool directory (if it still exists)

--- a/platform.py
+++ b/platform.py
@@ -123,17 +123,12 @@ def safe_remove_directory_pattern(base_path: str, pattern: str) -> bool:
     """Safely remove directories matching a pattern with error handling."""
     if not os.path.exists(base_path):
         return True
-        
-    try:
-        # Find all directories matching the pattern in the base directory
-        for item in os.listdir(base_path):
-            item_path = os.path.join(base_path, item)
-            if os.path.isdir(item_path) and fnmatch.fnmatch(item, pattern):
-                shutil.rmtree(item_path)
-                logger.debug(f"Directory removed: {item_path}")
-    except OSError as e:
-        logger.error(f"Error removing directories with pattern {pattern}: {e}")
-        return False
+    # Find all directories matching the pattern in the base directory
+    for item in os.listdir(base_path):
+        item_path = os.path.join(base_path, item)
+        if os.path.isdir(item_path) and fnmatch.fnmatch(item, pattern):
+            shutil.rmtree(item_path)
+            logger.debug(f"Directory removed: {item_path}")
     return True
 
 

--- a/platform.py
+++ b/platform.py
@@ -320,15 +320,14 @@ class Espressif32Platform(PlatformBase):
         # Wrong version, reinstall - remove similar paths too
         logger.info(f"Reinstalling {tool_name} due to version mismatch")
     
-        # Remove the main tool directory
-        safe_remove_directory(paths['tool_path'])
-    
-        # Also remove similar directories with version suffixes (e.g., xtensa.12232)
         tool_base_name = os.path.basename(paths['tool_path'])
         packages_dir = os.path.dirname(paths['tool_path'])
     
-        # Remove directories matching pattern like "toolname.*"
+        # Remove similar directories with version suffixes FIRST (e.g., xtensa.12232)
         safe_remove_directory_pattern(packages_dir, f"{tool_base_name}.*")
+    
+        # Then remove the main tool directory (if it still exists)
+        safe_remove_directory(paths['tool_path'])
     
         return self.install_tool(tool_name, retry_count + 1)
 

--- a/platform.py
+++ b/platform.py
@@ -168,6 +168,17 @@ class Espressif32Platform(PlatformBase):
         """Get centralized path calculation for tools with caching."""
         if tool_name not in self._tools_cache:
             tool_path = os.path.join(self.packages_dir, tool_name)
+            # Remove all directories containing '@' in their name
+            try:
+                for item in os.listdir(self.packages_dir):
+                    if '@' in item and item.startswith(tool_name):
+                        item_path = os.path.join(self.packages_dir, item)
+                        if os.path.isdir(item_path):
+                            safe_remove_directory(item_path)
+                            logger.debug(f"Removed directory with '@' in name: {item_path}")
+            except OSError as e:
+                logger.error(f"Error scanning packages directory for '@' directories: {e}")
+            
             self._tools_cache[tool_name] = {
                 'tool_path': tool_path,
                 'package_path': os.path.join(tool_path, "package.json"),


### PR DESCRIPTION
## Description:

The PR deletes all folders found with `@` in tool / toolchain folder name, before installing pioarduino tools / toolchains with tl-install.

Probably fix #208 

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cleanup of tool-related directories during installation and version updates, ensuring removal of outdated or versioned folders.
  * Enhanced error handling and logging for directory removal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->