### PR TITLE
Update mklittlefs versions, added Apple ARM native versions

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -120,14 +120,14 @@
       "optional": true,
       "owner": "pioarduino",
       "package-version": "3.2.0",
-      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/mklittlefs-3.2.0.zip"
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/mklittlefs-3.2.0-new.zip"
     },
-    "tool-mklittlefs-4.0.0": {
+    "tool-mklittlefs4": {
       "type": "uploader",
       "optional": true,
       "owner": "pioarduino",
-      "package-version": "4.0.0",
-      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/mklittlefs-4.0.0.zip"
+      "package-version": "4.0.2",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/mklittlefs-4.0.2.zip"
     },
     "tool-mkspiffs": {
       "type": "uploader",


### PR DESCRIPTION
## Description:

by using native Apple ARM versions of mklittlefs there should be no tool left which needs Rossetta 2

## Checklist:
  - [ ] The pull request is done against the latest develop branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [ ] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
