### PR TITLE
call esptool with full path

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -284,7 +284,7 @@ def install_esptool(env):
             scripts_dir = os.path.join(python_dir, "Scripts")
             esptool_exe = os.path.join(scripts_dir, "esptool.exe")
         else:
-            scripts_dir = os.path.join(python_dir, "bin")
+            scripts_dir = os.path.join(python_dir)
             esptool_exe = os.path.join(scripts_dir, "esptool")
 
         if os.path.isfile(esptool_exe):


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and usage of the correct esptool executable path in the build environment, ensuring compatibility with different platforms and handling paths with spaces.

* **Chores**
  * Updated internal handling of esptool installation to enhance reliability in locating the executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->