### PR TITLE
Full uv path

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -51,6 +51,7 @@ env = DefaultEnvironment()
 platform = env.PioPlatform()
 projectconfig = env.GetProjectConfig()
 terminal_cp = locale.getpreferredencoding().lower()
+PYTHON_EXE = env.subst("$PYTHONEXE")  # Global Python executable path
 
 # Framework directory path
 FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoespressif32")
@@ -80,24 +81,20 @@ def add_to_pythonpath(path):
         sys.path.insert(0, normalized_path)
 
 
-def setup_python_paths(env):
+def setup_python_paths():
     """
     Setup Python paths based on the actual Python executable being used.
-    
-    Args:
-        env: SCons environment object
     """
-    python_exe = env.subst('$PYTHONEXE')
-    if not python_exe or not os.path.isfile(python_exe):
+    if not PYTHON_EXE or not os.path.isfile(PYTHON_EXE):
         return
     
     # Get the directory containing the Python executable
-    python_dir = os.path.dirname(python_exe)
+    python_dir = os.path.dirname(PYTHON_EXE)
     add_to_pythonpath(python_dir)
     
     # Try to find site-packages directory using the actual Python executable
     result = subprocess.run(
-        [python_exe, "-c", "import site; print(site.getsitepackages()[0])"],
+        [PYTHON_EXE, "-c", "import site; print(site.getsitepackages()[0])"],
         capture_output=True,
         text=True,
         timeout=5
@@ -108,7 +105,7 @@ def setup_python_paths(env):
             add_to_pythonpath(site_packages)
 
 # Setup Python paths based on the actual Python executable
-setup_python_paths(env)
+setup_python_paths()
 
 
 def _get_executable_path(python_exe, executable_name):
@@ -200,7 +197,7 @@ def install_python_deps():
         bool: True if successful, False otherwise
     """
     # Get uv executable path
-    uv_executable = _get_uv_executable_path(env.subst("$PYTHONEXE"))
+    uv_executable = _get_uv_executable_path(PYTHON_EXE)
     
     try:
         result = subprocess.run(
@@ -216,7 +213,7 @@ def install_python_deps():
     if not uv_available:
         try:
             result = subprocess.run(
-                [env.subst("$PYTHONEXE"), "-m", "pip", "install", "uv>=0.1.0", "-q", "-q", "-q"],
+                [PYTHON_EXE, "-m", "pip", "install", "uv>=0.1.0", "-q", "-q", "-q"],
                 capture_output=True,
                 text=True,
                 timeout=30,  # 30 second timeout
@@ -228,11 +225,11 @@ def install_python_deps():
                 return False
             
             # Update uv executable path after installation
-            uv_executable = _get_uv_executable_path(env.subst("$PYTHONEXE"))
+            uv_executable = _get_uv_executable_path(PYTHON_EXE)
             
             # Add Scripts directory to PATH for Windows
             if sys.platform == "win32":
-                python_dir = os.path.dirname(env.subst("$PYTHONEXE"))
+                python_dir = os.path.dirname(PYTHON_EXE)
                 scripts_dir = os.path.join(python_dir, "Scripts")
                 if os.path.isdir(scripts_dir):
                     os.environ["PATH"] = scripts_dir + os.pathsep + os.environ.get("PATH", "")
@@ -297,7 +294,7 @@ def install_python_deps():
         
         cmd = [
             uv_executable, "pip", "install",
-            f"--python={env.subst('$PYTHONEXE')}",
+            f"--python={PYTHON_EXE}",
             "--quiet", "--upgrade"
         ] + packages_list
         
@@ -329,42 +326,37 @@ def install_python_deps():
     return True
 
 
-def install_esptool(env):
+def install_esptool():
     """
     Install esptool from package folder "tool-esptoolpy" using uv package manager.
     Also determines the path to the esptool executable binary.
     
-    Args:
-        env: SCons environment object
-        
     Returns:
         str: Path to esptool executable, or 'esptool' as fallback
     """
-    python_exe = env.subst("$PYTHONEXE")
-    
     try:
         subprocess.check_call(
-            [python_exe, "-c", "import esptool"], 
+            [PYTHON_EXE, "-c", "import esptool"], 
             stdout=subprocess.DEVNULL, 
             stderr=subprocess.DEVNULL,
             env=os.environ
         )
-        esptool_binary_path = _get_esptool_executable_path(python_exe)
+        esptool_binary_path = _get_esptool_executable_path(PYTHON_EXE)
         return esptool_binary_path
     except (subprocess.CalledProcessError, FileNotFoundError):
         pass
 
     esptool_repo_path = env.subst(platform.get_package_dir("tool-esptoolpy") or "")
     if esptool_repo_path and os.path.isdir(esptool_repo_path):
-        uv_executable = _get_uv_executable_path(python_exe)
+        uv_executable = _get_uv_executable_path(PYTHON_EXE)
         try:
             subprocess.check_call([
                 uv_executable, "pip", "install", "--quiet",
-                f"--python={python_exe}",
+                f"--python={PYTHON_EXE}",
                 "-e", esptool_repo_path
             ], env=os.environ)
 
-            esptool_binary_path = _get_esptool_executable_path(python_exe)
+            esptool_binary_path = _get_esptool_executable_path(PYTHON_EXE)
             return esptool_binary_path
             
         except subprocess.CalledProcessError as e:
@@ -376,7 +368,7 @@ def install_esptool(env):
 
 # Install Python dependencies and esptool
 install_python_deps()
-esptool_binary_path = install_esptool(env)
+esptool_binary_path = install_esptool()
 
 
 def BeforeUpload(target, source, env):
@@ -923,7 +915,7 @@ def firmware_metrics(target, source, env):
         return
 
     try:        
-        cmd = [env.subst("$PYTHONEXE"), "-m", "esp_idf_size", "--ng"]
+        cmd = [PYTHON_EXE, "-m", "esp_idf_size", "--ng"]
         
         # Parameters from platformio.ini
         extra_args = env.GetProjectOption("custom_esp_idf_size_args", "")
@@ -1051,7 +1043,7 @@ if upload_protocol == "espota":
     env.Replace(
         UPLOADER=join(FRAMEWORK_DIR, "tools", "espota.py"),
         UPLOADERFLAGS=["--debug", "--progress", "-i", "$UPLOAD_PORT"],
-        UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS -f $SOURCE',
+        UPLOADCMD=f'"{PYTHON_EXE}" "$UPLOADER" $UPLOADERFLAGS -f $SOURCE',
     )
     if set(["uploadfs", "uploadfsota"]) & set(COMMAND_LINE_TARGETS):
         env.Append(UPLOADERFLAGS=["--spiffs"])


### PR DESCRIPTION
## Description:

hopefully fixes Windows uv install issues. Adding Python virtual env scripts directory to Windows path

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of Python and related tool executable paths for better reliability across platforms.
  * Centralized Python executable path management for more consistent behavior.
  * Enhanced logic for locating and running required tools such as esptool and uv.

No user-facing features or interface changes were introduced in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->