### PR TITLE
Clear IDF_TOOLS_PATH

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -77,6 +77,9 @@ IS_WINDOWS = sys.platform.startswith("win")
 if IS_WINDOWS:
     os.environ["PLATFORMIO_SYSTEM_TYPE"] = "windows_amd64"
 
+# Clear IDF_TOOLS_PATH, if set tools may be installed in the wrong place
+os.environ["IDF_TOOLS_PATH"] = ""
+
 # Global variables
 python_exe = get_pythonexe_path()
 pm = ToolPackageManager()


### PR DESCRIPTION
## Description:

Clear the env variable IDF_TOOLS_PATH as it will change the folder where tools get installed. Most likely the Arduino IDE or some other tool install set this variable. As a result tools will not get installed into .platformio and the build will fail. A number of people hit this on windows.

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
