### PR TITLE
Enhanced tool-esp_install to try more connection ways to download packages

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -99,8 +99,8 @@
       "type": "tool",
       "optional": false,
       "owner": "pioarduino",
-      "package-version": "5.1.0",
-      "version": "https://github.com/pioarduino/esp_install/releases/download/v5.1.0/esp_install-v5.1.0.zip"
+      "package-version": "5.2.0",
+      "version": "https://github.com/pioarduino/esp_install/releases/download/v5.2.0/esp_install-v5.2.0.zip"
     },
     "contrib-piohome": {
       "optional": true,


### PR DESCRIPTION
- workaround for MacOS issues with custom cert provided in Installer, fallback to https when espressif cert is not working