### PR TITLE
try to fix debugger warnings by using new commands

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -827,6 +827,7 @@ class Espressif32Platform(PlatformBase):
                 },
                 "init_break": "thb app_main",
                 "init_cmds": [
+                    "set mi-async on",
                     "define pio_reset_halt_target",
                     "   monitor reset halt",
                     "   flushregs",

--- a/platform.py
+++ b/platform.py
@@ -830,7 +830,7 @@ class Espressif32Platform(PlatformBase):
                     "set mi-async on",
                     "define pio_reset_halt_target",
                     "   monitor reset halt",
-                    "   flushregs",
+                    "   maintenance flush register-cache",
                     "end",
                     "define pio_reset_run_target",
                     "   monitor reset",


### PR DESCRIPTION
## Description:

use of `set target-async` and `flushregs` are deprecated and generates warnings.

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
