### PR TITLE
tool-esp_install v5.3.0

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -99,8 +99,8 @@
       "type": "tool",
       "optional": false,
       "owner": "pioarduino",
-      "package-version": "5.2.0",
-      "version": "https://github.com/pioarduino/esp_install/releases/download/v5.2.0/esp_install-v5.2.0.zip"
+      "package-version": "5.3.0",
+      "version": "https://github.com/pioarduino/esp_install/releases/download/v5.3.0/esp_install-v5.3.0.zip"
     },
     "contrib-piohome": {
       "optional": true,


### PR DESCRIPTION
Installer download routine uses now urllib. Should fix download issues sometimes happens with Mac.


## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
