### PR TITLE
ULP: python path is already set

### DIFF
--- a/builder/frameworks/ulp.py
+++ b/builder/frameworks/ulp.py
@@ -17,7 +17,7 @@ import sys
 
 from platformio import fs
 from platformio.util import get_systype
-from platformio.proc import where_is_program, exec_command
+from platformio.proc import exec_command
 
 from SCons.Script import Import
 
@@ -48,13 +48,11 @@ def prepare_ulp_env_vars(env):
         else None
     )
 
-    python_dir = os.path.dirname(ulp_env.subst("$PYTHONEXE")) or ""
     additional_packages = [
         toolchain_path,
         toolchain_path_ulp,
         platform.get_package_dir("tool-ninja"),
         os.path.join(platform.get_package_dir("tool-cmake"), "bin"),
-        python_dir,
     ]
 
     for package in additional_packages:


### PR DESCRIPTION
## Description:

remove not needed adding Python path in ulp.py

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
