### PR TITLE
Update board Json files to use correct partition .csv files

### DIFF
--- a/boards/adafruit_feather_esp32s2.json
+++ b/boards/adafruit_feather_esp32s2.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s2_out.ld",
-      "partitions": "partitions-4MB-tinyuf2.csv",
+      "partitions": "tinyuf2-partitions-4MB.csv",
       "memory_type": "qio_qspi"
     },
     "core": "esp32",

--- a/boards/adafruit_feather_esp32s2_reversetft.json
+++ b/boards/adafruit_feather_esp32s2_reversetft.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s2_out.ld",
-      "partitions": "partitions-4MB-tinyuf2.csv"
+      "partitions": "tinyuf2-partitions-4MB.csv"
     },
     "core": "esp32",
     "extra_flags": [

--- a/boards/adafruit_feather_esp32s2_tft.json
+++ b/boards/adafruit_feather_esp32s2_tft.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s2_out.ld",
-      "partitions": "partitions-4MB-tinyuf2.csv",
+      "partitions": "tinyuf2-partitions-4MB.csv",
       "memory_type": "qio_qspi"
     },
     "core": "esp32",

--- a/boards/adafruit_feather_esp32s3.json
+++ b/boards/adafruit_feather_esp32s3.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino":{
       "ldscript": "esp32s3_out.ld",
-      "partitions": "partitions-4MB-tinyuf2.csv"
+      "partitions": "tinyuf2-partitions-4MB.csv.csv"
     },
     "core": "esp32",
     "extra_flags": [

--- a/boards/adafruit_feather_esp32s3_nopsram.json
+++ b/boards/adafruit_feather_esp32s3_nopsram.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino":{
       "ldscript": "esp32s3_out.ld",
-      "partitions": "partitions-8MB-tinyuf2.csv",
+      "partitions": "tinyuf2-partitions-8MB.csv",
       "memory_type": "qio_qspi"
     },
     "core": "esp32",

--- a/boards/adafruit_feather_esp32s3_reversetft.json
+++ b/boards/adafruit_feather_esp32s3_reversetft.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s3_out.ld",
-      "partitions": "partitions-4MB-tinyuf2.csv",
+      "partitions": "tinyuf2-partitions-4MB.csv",
       "memory_type": "qio_qspi"
     },
     "core": "esp32",

--- a/boards/adafruit_feather_esp32s3_tft.json
+++ b/boards/adafruit_feather_esp32s3_tft.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "arduino": {
-      "partitions": "partitions-4MB-tinyuf2.csv",
+      "partitions": "tinyuf2-partitions-4MB.csv",
       "memory_type": "qio_qspi"
     },
     "core": "esp32",

--- a/boards/adafruit_funhouse_esp32s2.json
+++ b/boards/adafruit_funhouse_esp32s2.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino":{
       "ldscript": "esp32s2_out.ld",
-      "partitions": "partitions-4MB-tinyuf2.csv"
+      "partitions": "tinyuf2-partitions-4MB.csv"
     },
     "core": "esp32",
     "extra_flags": [

--- a/boards/adafruit_magtag29_esp32s2.json
+++ b/boards/adafruit_magtag29_esp32s2.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino":{
       "ldscript": "esp32s2_out.ld",
-      "partitions": "partitions-4MB-tinyuf2.csv"
+      "partitions": "tinyuf2-partitions-4MB.csv"
     },
     "core": "esp32",
     "extra_flags": [

--- a/boards/adafruit_matrixportal_esp32s3.json
+++ b/boards/adafruit_matrixportal_esp32s3.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "arduino":{
-      "partitions": "partitions-8MB-tinyuf2.csv",
+      "partitions": "tinyuf2-partitions-8MB.csv",
       "memory_type": "qio_qspi"
     },
     "core": "esp32",

--- a/boards/adafruit_metro_esp32s2.json
+++ b/boards/adafruit_metro_esp32s2.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino":{
       "ldscript": "esp32s2_out.ld",
-      "partitions": "partitions-4MB-tinyuf2.csv"
+      "partitions": "tinyuf2-partitions-4MB.csv"
     },
     "core": "esp32",
     "extra_flags": [

--- a/boards/adafruit_metro_esp32s3.json
+++ b/boards/adafruit_metro_esp32s3.json
@@ -3,7 +3,7 @@
     "arduino":{
       "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_opi",
-      "partitions": "partitions-16MB-tinyuf2.csv"
+      "partitions": "tinyuf2-partitions-16MB.csv"
     },
     "core": "esp32",
     "extra_flags": [

--- a/boards/adafruit_qtpy_esp32s2.json
+++ b/boards/adafruit_qtpy_esp32s2.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s2_out.ld",
-      "partitions": "partitions-4MB-tinyuf2.csv"
+      "partitions": "tinyuf2-partitions-4MB.csv"
     },
     "core": "esp32",
     "extra_flags": [

--- a/boards/adafruit_qtpy_esp32s3_n4r2.json
+++ b/boards/adafruit_qtpy_esp32s3_n4r2.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s3_out.ld",
-      "partitions": "partitions-4MB-tinyuf2.csv"
+      "partitions": "tinyuf2-partitions-4MB.csv"
     },
     "core": "esp32",
     "extra_flags": [

--- a/boards/adafruit_qtpy_esp32s3_nopsram.json
+++ b/boards/adafruit_qtpy_esp32s3_nopsram.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s3_out.ld",
-      "partitions": "partitions-8MB-tinyuf2.csv"
+      "partitions": "tinyuf2-partitions-8MB.csv"
     },
     "core": "esp32",
     "extra_flags": [


### PR DESCRIPTION
## Description:
Some Adafruit boards were specifying the wrong partitions .csv file. These board Json files have been updated to the correct file names, as an example:
```
"partitions": "partitions-4MB-tinyuf2.csv"
changed to
"partitions": "tinyuf2-partitions-4MB.csv"
```
The boards affected are:
```
adafruit_feather_esp32s2		
adafruit_feather_esp32s2_reversetft	
adafruit_feather_esp32s2_tft		
adafruit_feather_esp32s3		
adafruit_feather_esp32s3_nopsram	
adafruit_feather_esp32s3_reversetft	
adafruit_feather_esp32s3_tft		
adafruit_funhouse_esp32s2		
adafruit_magtag29_esp32s2		
adafruit_matrixportal_esp32s3		 
adafruit_metro_esp32s2			
adafruit_metro_esp32s3			
adafruit_qtpy_esp32s2			
adafruit_qtpy_esp32s3_n4r2		
adafruit_qtpy_esp32s3_nopsram
```

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [ X] The pull request is done against the latest develop branch
  - [X] Only relevant files were touched
  - [X ] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [X ] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
