### PR TITLE
Refactor tool installation by removing timeout and retries

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -396,7 +396,11 @@ class Espressif32Platform(PlatformBase):
         }
 
     def _run_idf_tools_install(self, tools_json_path: str, idf_tools_path: str) -> bool:
-        """Execute idf_tools.py install command."""
+        """
+        Execute idf_tools.py install command.
+        Note: No timeout is set to allow installations to complete on slow networks.
+        The tool-esp_install handles the retry logic.
+        """
         cmd = [
             python_exe,
             idf_tools_path,
@@ -408,6 +412,7 @@ class Espressif32Platform(PlatformBase):
         ]
 
         try:
+            logger.info(f"Installing tools via idf_tools.py (this may take several minutes)...")
             result = subprocess.run(
                 cmd,
                 stdout=subprocess.DEVNULL,


### PR DESCRIPTION
## Description:

fix install issues with slow internet and computers. Better prefer hang before Interrupt of install.
Let tool-esp_install handle the retry attempts.

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified tool installation flow by removing automatic retries and timeouts.
  - Installs now fail fast with clearer error reporting.
  - Consistent behavior across all devices (no device-specific timeouts).

- Documentation
  - Updated installation guidance to reflect the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->