### PR TITLE
Fix m5stack_core_esp32 related board variants

### DIFF
--- a/boards/m5stack-core-esp32-16M.json
+++ b/boards/m5stack-core-esp32-16M.json
@@ -4,12 +4,12 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_M5Stack_Core_ESP32",
+    "extra_flags": "-DARDUINO_M5Stack_Core",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "qio",
     "mcu": "esp32",
-    "variant": "m5stack_core_esp32"
+    "variant": "m5stack_core"
   },
   "connectivity": [
     "wifi",

--- a/boards/m5stack-core-esp32.json
+++ b/boards/m5stack-core-esp32.json
@@ -4,12 +4,12 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_M5Stack_Core_ESP32",
+    "extra_flags": "-DARDUINO_M5Stack_Core",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "qio",
     "mcu": "esp32",
-    "variant": "m5stack_core_esp32"
+    "variant": "m5stack_core"
   },
   "connectivity": [
     "wifi",

--- a/boards/m5stack-grey.json
+++ b/boards/m5stack-grey.json
@@ -4,12 +4,12 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_M5Stack_Core_ESP32",
+    "extra_flags": "-DARDUINO_M5Stack_Core",
     "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",
     "mcu": "esp32",
-    "variant": "m5stack_core_esp32"
+    "variant": "m5stack_core"
   },
   "connectivity": [
     "wifi",


### PR DESCRIPTION
## Description:

In the espressif/arduino-esp32 repository the variant m5stack_core_esp32 was renamed to m5stack_core.

See https://github.com/espressif/arduino-esp32/commit/a1c86ae936c06fd1d7b193986152464cdd4db2ad#diff-498a5473e69c1931584e14350d29bc3f8b22f7cf7469d3ef81c896298c9f9291 Therefore some m5stack boards were updated correspondingly.

**Related issue (if applicable):** fixes #288 

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
