### PR TITLE
penv setup moved in platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Prerequisites:
 The Wiki is AI generated and insane detailed and accurate.
 
 ### Stable Arduino
-currently espressif Arduino 3.3.1 and IDF 5.5.1
+currently espressif Arduino 3.3.2 and IDF 5.5.1.250929
 
 ```ini
 [env:stable]

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -886,7 +886,7 @@ if check_reinstall_frwrk():
 if flag_custom_sdkconfig and not flag_any_custom_sdkconfig:
     call_compile_libs()
 
-# Main logic for Arduino Framework
+# Arduino framework configuration and build logic
 pioframework = env.subst("$PIOFRAMEWORK")
 arduino_lib_compile_flag = env.subst("$ARDUINO_LIB_COMPILE_FLAG")
 

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -22,10 +22,10 @@ kinds of creative coding, interactive objects, spaces or physical experiences.
 http://arduino.cc/en/Reference/HomePage
 """
 
-import os
-import sys
-import shutil
 import hashlib
+import os
+import shutil
+import sys
 import threading
 from contextlib import suppress
 from os.path import join, exists, isabs, splitdrive, commonpath, relpath

--- a/builder/frameworks/component_manager.py
+++ b/builder/frameworks/component_manager.py
@@ -12,9 +12,9 @@ import os
 import shutil
 import re
 import yaml
-from yaml import SafeLoader
 from pathlib import Path
 from typing import Set, Optional, Dict, Any, List, Tuple, Pattern
+from yaml import SafeLoader
 
 
 class ComponentManagerConfig:

--- a/builder/frameworks/component_manager.py
+++ b/builder/frameworks/component_manager.py
@@ -252,7 +252,7 @@ class ComponentHandler:
         Returns:
             Absolute path to the component YAML file
         """
-        # Try Arduino framework first
+        # Check Arduino framework directory first
         afd = self.config.arduino_framework_dir
         framework_yml = str(Path(afd) / "idf_component.yml") if afd else ""
         if framework_yml and os.path.exists(framework_yml):

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1530,6 +1530,7 @@ def install_python_deps():
         # https://github.com/platformio/platform-espressif32/issues/635
         "cryptography": "~=44.0.0",
         "pyparsing": ">=3.1.0,<4",
+        "pydantic": "~=2.11.10",
         "idf-component-manager": "~=2.2",
         "esp-idf-kconfig": "~=2.5.0"
     }

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -23,14 +23,14 @@ https://github.com/espressif/esp-idf
 import copy
 import importlib.util
 import json
-import subprocess
-import sys
-import shutil
 import os
-from os.path import join
+import platform as sys_platform
 import re
 import requests
-import platform as sys_platform
+import shutil
+import subprocess
+import sys
+from os.path import join
 from pathlib import Path
 from urllib.parse import urlsplit, unquote
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1672,8 +1672,8 @@ def get_python_exe():
 
 ensure_python_venv_available()
 
-# ESP-IDF package doesn't contain .git folder, instead package version is specified
-# in a special file "version.h" in the root folder of the package
+# ESP-IDF package version is determined from version.h file
+# since the package distribution doesn't include .git metadata
 
 create_version_file()
 
@@ -1712,7 +1712,7 @@ if not board.get("build.ldscript", ""):
 
 
 #
-# Current build script limitations
+# Known build system limitations
 #
 
 if any(" " in p for p in (FRAMEWORK_DIR, BUILD_DIR)):
@@ -1751,12 +1751,12 @@ if "arduino" in env.subst("$PIOFRAMEWORK"):
         LIBSOURCE_DIRS=[str(Path(ARDUINO_FRAMEWORK_DIR) / "libraries")]
     )
 
-# Set ESP-IDF version environment variables (needed for proper Kconfig processing)
+# Configure ESP-IDF version environment variables for Kconfig processing
 framework_version = get_framework_version()
 major_version = framework_version.split('.')[0] + '.' + framework_version.split('.')[1]
 os.environ["ESP_IDF_VERSION"] = major_version
 
-# Configure CMake arguments with ESP-IDF version
+# Setup CMake configuration arguments
 extra_cmake_args = [
     "-DIDF_TARGET=" + idf_variant,
     "-DPYTHON_DEPS_CHECKED=1",
@@ -1850,7 +1850,7 @@ if flag_custom_sdkonfig == False:
     env.Depends("$BUILD_DIR/$PROGNAME$PROGSUFFIX", build_bootloader(sdk_config))
 
 #
-# Target: ESP-IDF menuconfig
+# ESP-IDF menuconfig target implementation
 #
 
 env.AddPlatformTarget(
@@ -1995,8 +1995,8 @@ if "__test" not in COMMAND_LINE_TARGETS or env.GetProjectOption(
 ):
     project_env = env.Clone()
     if project_target_name != "__idf_main":
-        # Manually add dependencies to CPPPATH since ESP-IDF build system doesn't generate
-        # this info if the folder with sources is not named 'main'
+        # Add dependencies to CPPPATH for non-main source directories
+        # ESP-IDF build system requires manual dependency handling for custom source folders
         # https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/build-system.html#rename-main
         project_env.AppendUnique(CPPPATH=app_includes["plain_includes"])
 
@@ -2044,7 +2044,7 @@ if board_flash_size != idf_flash_size:
 #
 
 extra_elf2bin_flags = "--elf-sha256-offset 0xb0"
-# https://github.com/espressif/esp-idf/blob/master/components/esptool_py/project_include.cmake#L58
+# Reference: ESP-IDF esptool_py component configuration
 # For chips that support configurable MMU page size feature
 # If page size is configured to values other than the default "64KB" in menuconfig,
 mmu_page_size = "64KB"

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -30,7 +30,6 @@ import requests
 import shutil
 import subprocess
 import sys
-from os.path import join
 from pathlib import Path
 from urllib.parse import urlsplit, unquote
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -444,7 +444,6 @@ def HandleArduinoIDFsettings(env):
         if f_flash and compile_freq:
             # Ensure frequency compatibility (>= 80MHz must be identical for Flash and PSRAM)
             compile_freq_val = int(str(compile_freq).replace("000000L", ""))
-            esptool_freq_val = int(str(esptool_flash_freq).replace("000000L", ""))
             
             if compile_freq_val >= 80:
                 # Above 80MHz, both Flash and PSRAM must use same frequency

--- a/builder/main.py
+++ b/builder/main.py
@@ -34,7 +34,6 @@ from SCons.Script import (
 from platformio.project.helpers import get_project_dir
 from platformio.util import get_serial_ports
 from platformio.compat import IS_WINDOWS
-from penv_setup import setup_python_environment
 
 # Initialize environment and configuration
 env = DefaultEnvironment()
@@ -47,7 +46,7 @@ core_dir = projectconfig.get("platformio", "core_dir")
 build_dir = Path(projectconfig.get("platformio", "build_dir"))
 
 # Setup Python virtual environment and get executable paths
-PYTHON_EXE, esptool_binary_path = setup_python_environment(env, platform, core_dir)
+PYTHON_EXE, esptool_binary_path = platform.setup_python_env(env)
 
 # Initialize board configuration and MCU settings
 board = env.BoardConfig()

--- a/builder/main.py
+++ b/builder/main.py
@@ -35,7 +35,7 @@ from platformio.project.helpers import get_project_dir
 from platformio.util import get_serial_ports
 from platformio.compat import IS_WINDOWS
 
-# Initialize environment and configuration
+# Initialize SCons environment and project configuration
 env = DefaultEnvironment()
 platform = env.PioPlatform()
 projectconfig = env.GetProjectConfig()
@@ -45,10 +45,10 @@ framework_dir = platform.get_package_dir("framework-arduinoespressif32")
 core_dir = projectconfig.get("platformio", "core_dir")
 build_dir = Path(projectconfig.get("platformio", "build_dir"))
 
-# Setup Python virtual environment and get executable paths
+# Configure Python environment through centralized platform management
 PYTHON_EXE, esptool_binary_path = platform.setup_python_env(env)
 
-# Initialize board configuration and MCU settings
+# Load board configuration and determine MCU architecture
 board = env.BoardConfig()
 board_id = env.subst("$BOARD")
 mcu = board.get("build.mcu", "esp32")
@@ -450,7 +450,7 @@ load_board_script(env)
 if not is_xtensa:
     toolchain_arch = "riscv32-esp"
 
-# Initialize integration extra data if not present
+# Ensure integration extra data structure exists
 if "INTEGRATION_EXTRA_DATA" not in env:
     env["INTEGRATION_EXTRA_DATA"] = {}
 
@@ -460,7 +460,7 @@ uploader_path = (
     if ' ' in esptool_binary_path 
     else esptool_binary_path
 )
-# Configure build tools and environment variables
+# Configure SCons build tools and compiler settings
 env.Replace(
     __get_board_boot_mode=_get_board_boot_mode,
     __get_board_f_flash=_get_board_f_flash,
@@ -636,7 +636,7 @@ def firmware_metrics(target, source, env):
         if env.GetProjectOption("custom_esp_idf_size_verbose", False):
             print(f"Running command: {' '.join(cmd)}")
         
-        # Call esp-idf-size with modified environment
+        # Execute esp-idf-size with current environment
         result = subprocess.run(cmd, check=False, capture_output=False, env=os.environ)
         
         if result.returncode != 0:

--- a/builder/main.py
+++ b/builder/main.py
@@ -611,7 +611,7 @@ def firmware_metrics(target, source, env):
         return
 
     try:        
-        cmd = [PYTHON_EXE, "-m", "esp_idf_size", "--ng"]
+        cmd = [PYTHON_EXE, "-m", "esp_idf_size"]
         
         # Parameters from platformio.ini
         extra_args = env.GetProjectOption("custom_esp_idf_size_args", "")

--- a/builder/main.py
+++ b/builder/main.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.util
 import locale
 import os
 import re
@@ -20,7 +21,6 @@ import subprocess
 import sys
 from os.path import isfile, join
 from pathlib import Path
-import importlib.util
 
 from SCons.Script import (
     ARGUMENTS,

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -400,12 +400,11 @@ def install_esptool(env, platform, python_exe, uv_executable):
         sys.exit(1)
 
 
-def setup_python_environment(env, platform, platformio_dir):
+def setup_penv_minimal(platform, platformio_dir):
     """
-    Main function to setup the Python virtual environment and dependencies.
+    Minimal Python virtual environment setup without SCons dependencies.
     
     Args:
-        env: SCons environment object
         platform: PlatformIO platform object
         platformio_dir (str): Path to PlatformIO core directory
     
@@ -414,6 +413,21 @@ def setup_python_environment(env, platform, platformio_dir):
         
     Raises:
         SystemExit: If Python version < 3.10 or dependency installation fails
+    """
+    return _setup_python_environment_core(None, platform, platformio_dir)
+
+
+def _setup_python_environment_core(env, platform, platformio_dir):
+    """
+    Core Python environment setup logic shared by both SCons and minimal versions.
+    
+    Args:
+        env: SCons environment object (None for minimal setup)
+        platform: PlatformIO platform object
+        platformio_dir (str): Path to PlatformIO core directory
+    
+    Returns:
+        tuple[str, str]: (Path to penv Python executable, Path to esptool script)
     """
     # Check Python version requirement
     if sys.version_info < (3, 10):
@@ -427,11 +441,19 @@ def setup_python_environment(env, platform, platformio_dir):
     penv_dir = str(Path(platformio_dir) / "penv")
     
     # Setup virtual environment if needed
-    used_uv_executable = setup_pipenv_in_package(env, penv_dir)
+    if env is not None:
+        # SCons version
+        used_uv_executable = setup_pipenv_in_package(env, penv_dir)
+    else:
+        # Minimal version
+        used_uv_executable = _setup_pipenv_minimal(penv_dir)
     
-    # Set Python Scons Var to env Python
+    # Set Python executable path
     penv_python = get_executable_path(penv_dir, "python")
-    env.Replace(PYTHONEXE=penv_python)
+    
+    # Update SCons environment if available
+    if env is not None:
+        env.Replace(PYTHONEXE=penv_python)
     
     # check for python binary, exit with error when not found
     assert os.path.isfile(penv_python), f"Python executable not found: {penv_python}"
@@ -452,21 +474,152 @@ def setup_python_environment(env, platform, platformio_dir):
         print("Warning: No internet connection detected, Python dependency check will be skipped.")
 
     # Install esptool after dependencies
-    install_esptool(env, platform, penv_python, uv_executable)
+    if env is not None:
+        # SCons version
+        install_esptool(env, platform, penv_python, uv_executable)
+    else:
+        # Minimal version
+        _install_esptool_minimal(platform, penv_python, uv_executable)
 
     # Setup certifi environment variables
-    def setup_certifi_env():
+    _setup_certifi_env(env)
+
+    return penv_python, esptool_binary_path
+
+
+def _setup_pipenv_minimal(penv_dir):
+    """
+    Setup virtual environment without SCons dependencies.
+    
+    Args:
+        penv_dir (str): Path to virtual environment directory
+        
+    Returns:
+        str or None: Path to uv executable if uv was used, None if python -m venv was used
+    """
+    if not os.path.exists(penv_dir):
+        # First try to create virtual environment with uv
+        uv_success = False
+        uv_cmd = None
         try:
-            import certifi
-        except ImportError:
-            print("Info: certifi not available; skipping CA environment setup.")
+            # Derive uv path from current Python path
+            python_dir = os.path.dirname(sys.executable)
+            uv_exe_suffix = ".exe" if IS_WINDOWS else ""
+            uv_cmd = str(Path(python_dir) / f"uv{uv_exe_suffix}")
+            
+            # Fall back to system uv if derived path doesn't exist
+            if not os.path.isfile(uv_cmd):
+                uv_cmd = "uv"
+                
+            subprocess.check_call(
+                [uv_cmd, "venv", "--clear", f"--python={sys.executable}", penv_dir],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=90
+            )
+            uv_success = True
+            print(f"Created pioarduino Python virtual environment using uv: {penv_dir}")
+
+        except Exception:
+            pass
+        
+        # Fallback to python -m venv if uv failed or is not available
+        if not uv_success:
+            uv_cmd = None
+            cmd = f'"{sys.executable}" -m venv --clear "{penv_dir}"'
+            try:
+                subprocess.run(cmd, shell=True, check=True)
+                print(f"Created pioarduino Python virtual environment: {penv_dir}")
+            except subprocess.CalledProcessError as e:
+                sys.stderr.write(f"Error: Failed to create virtual environment: {e}\n")
+                sys.exit(1)
+        
+        # Verify that the virtual environment was created properly
+        # Check for python executable
+        assert os.path.isfile(
+            get_executable_path(penv_dir, "python")
+        ), f"Error: Failed to create a proper virtual environment. Missing the `python` binary! Created with uv: {uv_success}"
+        
+        return uv_cmd if uv_success else None
+    
+    return None
+
+
+def _install_esptool_minimal(platform, python_exe, uv_executable):
+    """
+    Install esptool from package folder "tool-esptoolpy" without SCons dependencies.
+    
+    Args:
+        platform: PlatformIO platform object  
+        python_exe (str): Path to Python executable in virtual environment
+        uv_executable (str): Path to uv executable
+    
+    Raises:
+        SystemExit: If esptool installation fails or package directory not found
+    """
+    esptool_repo_path = platform.get_package_dir("tool-esptoolpy") or ""
+    if not esptool_repo_path or not os.path.isdir(esptool_repo_path):
+        sys.stderr.write(
+            f"Error: 'tool-esptoolpy' package directory not found: {esptool_repo_path!r}\n"
+        )
+        sys.exit(1)
+
+    # Check if esptool is already installed from the correct path
+    try:
+        result = subprocess.run(
+            [
+                python_exe,
+                "-c",
+                (
+                    "import esptool, os, sys; "
+                    "expected_path = os.path.normcase(os.path.realpath(sys.argv[1])); "
+                    "actual_path = os.path.normcase(os.path.realpath(os.path.dirname(esptool.__file__))); "
+                    "print('MATCH' if actual_path.startswith(expected_path) else 'MISMATCH')"
+                ),
+                esptool_repo_path,
+            ],
+            capture_output=True,
+            check=True,
+            text=True,
+            timeout=5
+        )
+        
+        if result.stdout.strip() == "MATCH":
             return
-        cert_path = certifi.where()
-        os.environ["CERTIFI_PATH"] = cert_path
-        os.environ["SSL_CERT_FILE"] = cert_path
-        os.environ["REQUESTS_CA_BUNDLE"] = cert_path
-        os.environ["CURL_CA_BUNDLE"] = cert_path
-        # Also propagate to SCons environment for future env.Execute calls
+            
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    try:
+        subprocess.check_call([
+            uv_executable, "pip", "install", "--quiet", "--force-reinstall",
+            f"--python={python_exe}",
+            "-e", esptool_repo_path
+        ], timeout=60)
+
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write(
+            f"Error: Failed to install esptool from {esptool_repo_path} (exit {e.returncode})\n"
+        )
+        sys.exit(1)
+
+
+def _setup_certifi_env(env):
+    """Setup certifi environment variables with optional SCons integration."""
+    try:
+        import certifi
+    except ImportError:
+        print("Info: certifi not available; skipping CA environment setup.")
+        return
+    
+    cert_path = certifi.where()
+    os.environ["CERTIFI_PATH"] = cert_path
+    os.environ["SSL_CERT_FILE"] = cert_path
+    os.environ["REQUESTS_CA_BUNDLE"] = cert_path
+    os.environ["CURL_CA_BUNDLE"] = cert_path
+    
+    # Also propagate to SCons environment if available
+    if env is not None:
         env_vars = dict(env.get("ENV", {}))
         env_vars.update({
             "CERTIFI_PATH": cert_path,
@@ -476,6 +629,20 @@ def setup_python_environment(env, platform, platformio_dir):
         })
         env.Replace(ENV=env_vars)
 
-    setup_certifi_env()
 
-    return penv_python, esptool_binary_path
+def setup_python_environment(env, platform, platformio_dir):
+    """
+    Main function to setup the Python virtual environment and dependencies.
+    
+    Args:
+        env: SCons environment object
+        platform: PlatformIO platform object
+        platformio_dir (str): Path to PlatformIO core directory
+    
+    Returns:
+        tuple[str, str]: (Path to penv Python executable, Path to esptool script)
+        
+    Raises:
+        SystemExit: If Python version < 3.10 or dependency installation fails
+    """
+    return _setup_python_environment_core(env, platform, platformio_dir)

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -497,7 +497,7 @@ def _setup_pipenv_minimal(penv_dir):
     Returns:
         str or None: Path to uv executable if uv was used, None if python -m venv was used
     """
-    if not os.path.exists(penv_dir):
+    if not os.path.isfile(get_executable_path(penv_dir, "python")):
         # Attempt virtual environment creation using uv package manager
         uv_success = False
         uv_cmd = None

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -34,7 +34,7 @@ if sys.version_info < (3, 10):
     )
     sys.exit(1)
 
-github_actions = os.getenv('GITHUB_ACTIONS')
+github_actions = bool(os.getenv("GITHUB_ACTIONS"))
 
 PLATFORMIO_URL_VERSION_RE = re.compile(
     r'/v?(\d+\.\d+\.\d+(?:[.-]\w+)?(?:\.\d+)?)(?:\.(?:zip|tar\.gz|tar\.bz2))?$',

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -606,10 +606,7 @@ def _install_esptool_from_tl_install(platform, python_exe, uv_executable):
         # Don't exit - esptool installation is not critical for penv setup
 
 
-
-
-
-def _setup_certifi_env(env, python_exe=None):
+def _setup_certifi_env(env, python_exe):
     """
     Setup certifi environment variables from the given python_exe virtual environment.
     Uses a subprocess call to extract certifi path from that environment to guarantee penv usage.
@@ -631,6 +628,7 @@ def _setup_certifi_env(env, python_exe=None):
     os.environ["SSL_CERT_FILE"] = cert_path
     os.environ["REQUESTS_CA_BUNDLE"] = cert_path
     os.environ["CURL_CA_BUNDLE"] = cert_path
+    os.environ["GIT_SSL_CAINFO"] = cert_path
 
     # Also propagate to SCons environment if available
     if env is not None:

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -562,7 +562,7 @@ def _install_esptool_from_tl_install(platform, python_exe, uv_executable):
     # Get esptool path from tool-esptoolpy package (provided by tl-install)
     esptool_repo_path = platform.get_package_dir("tool-esptoolpy") or ""
     if not esptool_repo_path or not os.path.isdir(esptool_repo_path):
-        return
+        return (None, None)
 
     # Check if esptool is already installed from the correct path
     try:

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -356,7 +356,7 @@ def install_esptool(env, platform, python_exe, uv_executable):
     Raises:
         SystemExit: If esptool installation fails or package directory not found
     """
-    esptool_repo_path = env.subst(platform.get_package_dir("tool-esptoolpy") or "")
+    esptool_repo_path = platform.get_package_dir("tool-esptoolpy") or ""
     if not esptool_repo_path or not os.path.isdir(esptool_repo_path):
         sys.stderr.write(
             f"Error: 'tool-esptoolpy' package directory not found: {esptool_repo_path!r}\n"

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -415,10 +415,10 @@ def setup_penv_minimal(platform, platformio_dir, install_esptool=True):
     Raises:
         SystemExit: If Python version < 3.10 or dependency installation fails
     """
-    return _setup_python_environment_core(None, platform, platformio_dir, install_esptool)
+    return _setup_python_environment_core(None, platform, platformio_dir, should_install_esptool=install_esptool)
 
 
-def _setup_python_environment_core(env, platform, platformio_dir, install_esptool=True):
+def _setup_python_environment_core(env, platform, platformio_dir, should_install_esptool=True):
     """
     Core Python environment setup logic shared by both SCons and minimal versions.
     
@@ -426,7 +426,7 @@ def _setup_python_environment_core(env, platform, platformio_dir, install_esptoo
         env: SCons environment object (None for minimal setup)
         platform: PlatformIO platform object
         platformio_dir (str): Path to PlatformIO core directory
-        install_esptool (bool): Whether to install esptool (default: True)
+        should_install_esptool (bool): Whether to install esptool (default: True)
     
     Returns:
         tuple[str, str]: (Path to penv Python executable, Path to esptool script)
@@ -476,7 +476,7 @@ def _setup_python_environment_core(env, platform, platformio_dir, install_esptoo
         print("Warning: No internet connection detected, Python dependency check will be skipped.")
 
     # Install esptool after dependencies (if requested)
-    if install_esptool:
+    if should_install_esptool:
         if env is not None:
             # SCons version
             install_esptool(env, platform, penv_python, uv_executable)
@@ -648,4 +648,4 @@ def setup_python_environment(env, platform, platformio_dir):
     Raises:
         SystemExit: If Python version < 3.10 or dependency installation fails
     """
-    return _setup_python_environment_core(env, platform, platformio_dir, install_esptool=True)
+    return _setup_python_environment_core(env, platform, platformio_dir, should_install_esptool=True)

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -223,7 +223,7 @@ def install_python_deps(python_exe, external_uv_executable):
                     [external_uv_executable, "pip", "install", "uv>=0.1.0", f"--python={python_exe}", "--quiet"],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.STDOUT,
-                    timeout=120
+                    timeout=300
                 )
             except subprocess.CalledProcessError as e:
                 print(f"Error: uv installation failed with exit code {e.returncode}")
@@ -244,7 +244,7 @@ def install_python_deps(python_exe, external_uv_executable):
                     [python_exe, "-m", "pip", "install", "uv>=0.1.0", "--quiet"],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.STDOUT,
-                    timeout=120
+                    timeout=300
                 )
             except subprocess.CalledProcessError as e:
                 print(f"Error: uv installation via pip failed with exit code {e.returncode}")
@@ -275,7 +275,7 @@ def install_python_deps(python_exe, external_uv_executable):
                 capture_output=True,
                 text=True,
                 encoding='utf-8',
-                timeout=120
+                timeout=300
             )
             
             if result_obj.returncode == 0:
@@ -323,7 +323,7 @@ def install_python_deps(python_exe, external_uv_executable):
                 cmd,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.STDOUT,
-                timeout=120
+                timeout=300
             )
                 
         except subprocess.CalledProcessError as e:

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -64,10 +64,9 @@ def has_internet_connection(host="1.1.1.1", port=53, timeout=2):
     Returns True if a connection is possible, otherwise False.
     """
     try:
-        socket.setdefaulttimeout(timeout)
-        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((host, port))
-        return True
-    except Exception:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
         return False
 
 

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -15,11 +15,11 @@
 import json
 import os
 import re
-import site
 import semantic_version
+import site
+import socket
 import subprocess
 import sys
-import socket
 from pathlib import Path
 
 from platformio.package.version import pepver_to_semver

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -400,7 +400,7 @@ def install_esptool(env, platform, python_exe, uv_executable):
         sys.exit(1)
 
 
-def setup_penv_minimal(platform, platformio_dir, install_esptool=True):
+def setup_penv_minimal(platform, platformio_dir: str, install_esptool: bool = True):
     """
     Minimal Python virtual environment setup without SCons dependencies.
     
@@ -529,9 +529,10 @@ def _setup_pipenv_minimal(penv_dir):
         # Fallback to python -m venv if uv failed or is not available
         if not uv_success:
             uv_cmd = None
-            cmd = f'"{sys.executable}" -m venv --clear "{penv_dir}"'
             try:
-                subprocess.run(cmd, shell=True, check=True)
+                subprocess.check_call([
+                    sys.executable, "-m", "venv", "--clear", penv_dir
+                ])
                 print(f"Created pioarduino Python virtual environment: {penv_dir}")
             except subprocess.CalledProcessError as e:
                 sys.stderr.write(f"Error: Failed to create virtual environment: {e}\n")

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -49,6 +49,7 @@ python_deps = {
     "zopfli": ">=0.2.2",
     "intelhex": ">=2.3.0",
     "rich": ">=14.0.0",
+    "urllib3": "<2",
     "cryptography": ">=45.0.3",
     "certifi": ">=2025.8.3",
     "ecdsa": ">=0.19.1",

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -89,7 +89,7 @@ def setup_pipenv_in_package(env, penv_dir):
     Returns:
         str or None: Path to uv executable if uv was used, None if python -m venv was used
     """
-    if not os.path.exists(penv_dir):
+    if not os.path.isfile(get_executable_path(penv_dir, "python")):
         # Attempt virtual environment creation using uv package manager
         uv_success = False
         uv_cmd = None

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -620,6 +620,7 @@ def _setup_certifi_env(env):
             "SSL_CERT_FILE": cert_path,
             "REQUESTS_CA_BUNDLE": cert_path,
             "CURL_CA_BUNDLE": cert_path,
+            "GIT_SSL_CAINFO": cert_path,
         })
         env.Replace(ENV=env_vars)
 

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -41,7 +41,7 @@ PLATFORMIO_URL_VERSION_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Python dependencies required for the build process
+# Python dependencies required for ESP32 platform builds
 python_deps = {
     "platformio": "https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.18.zip",
     "pyyaml": ">=6.0.2",
@@ -89,7 +89,7 @@ def setup_pipenv_in_package(env, penv_dir):
         str or None: Path to uv executable if uv was used, None if python -m venv was used
     """
     if not os.path.exists(penv_dir):
-        # First try to create virtual environment with uv
+        # Attempt virtual environment creation using uv package manager
         uv_success = False
         uv_cmd = None
         try:
@@ -125,8 +125,8 @@ def setup_pipenv_in_package(env, penv_dir):
                 )
             )
         
-        # Verify that the virtual environment was created properly
-        # Check for python executable
+        # Validate virtual environment creation
+        # Ensure Python executable is available
         assert os.path.isfile(
             get_executable_path(penv_dir, "python")
         ), f"Error: Failed to create a proper virtual environment. Missing the `python` binary! Created with uv: {uv_success}"
@@ -432,7 +432,7 @@ def _setup_python_environment_core(env, platform, platformio_dir, should_install
     """
     penv_dir = str(Path(platformio_dir) / "penv")
     
-    # Setup virtual environment if needed
+    # Create virtual environment if not present
     if env is not None:
         # SCons version
         used_uv_executable = setup_pipenv_in_package(env, penv_dir)
@@ -457,7 +457,7 @@ def _setup_python_environment_core(env, platform, platformio_dir, should_install
     esptool_binary_path = get_executable_path(penv_dir, "esptool")
     uv_executable = get_executable_path(penv_dir, "uv")
 
-    # Install espressif32 Python dependencies
+    # Install required Python dependencies for ESP32 platform
     if has_internet_connection() or github_actions:
         if not install_python_deps(penv_python, used_uv_executable):
             sys.stderr.write("Error: Failed to install Python dependencies into penv\n")
@@ -465,13 +465,13 @@ def _setup_python_environment_core(env, platform, platformio_dir, should_install
     else:
         print("Warning: No internet connection detected, Python dependency check will be skipped.")
 
-    # Install esptool after dependencies (if requested)
+    # Install esptool package if required
     if should_install_esptool:
         if env is not None:
             # SCons version
             install_esptool(env, platform, penv_python, uv_executable)
         else:
-            # Minimal version - install esptool from tl-install provided path
+            # Minimal setup - install esptool from tool package
             _install_esptool_from_tl_install(platform, penv_python, uv_executable)
 
     # Setup certifi environment variables
@@ -491,7 +491,7 @@ def _setup_pipenv_minimal(penv_dir):
         str or None: Path to uv executable if uv was used, None if python -m venv was used
     """
     if not os.path.exists(penv_dir):
-        # First try to create virtual environment with uv
+        # Attempt virtual environment creation using uv package manager
         uv_success = False
         uv_cmd = None
         try:
@@ -528,8 +528,8 @@ def _setup_pipenv_minimal(penv_dir):
                 sys.stderr.write(f"Error: Failed to create virtual environment: {e}\n")
                 sys.exit(1)
         
-        # Verify that the virtual environment was created properly
-        # Check for python executable
+        # Validate virtual environment creation
+        # Ensure Python executable is available
         assert os.path.isfile(
             get_executable_path(penv_dir, "python")
         ), f"Error: Failed to create a proper virtual environment. Missing the `python` binary! Created with uv: {uv_success}"

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -55,7 +55,7 @@ python_deps = {
     "ecdsa": ">=0.19.1",
     "bitstring": ">=4.3.1",
     "reedsolo": ">=1.5.3,<1.8",
-    "esp-idf-size": ">=1.6.1"
+    "esp-idf-size": ">=2.0.0"
 }
 
 

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -611,29 +611,21 @@ def _install_esptool_from_tl_install(platform, python_exe, uv_executable):
 
 def _setup_certifi_env(env, python_exe=None):
     """
-    Setup certifi environment variables with priority from the given python_exe virtual environment.
-    If python_exe is provided, runs a subprocess to extract certifi path from that env to guarantee penv usage.
-    Falls back to importing certifi from current environment on failure.
+    Setup certifi environment variables from the given python_exe virtual environment.
+    Uses a subprocess call to extract certifi path from that environment to guarantee penv usage.
     """
-    cert_path = None
-    if python_exe:
-        try:
-            # Run python executable from penv to get certifi path
-            out = subprocess.check_output(
-                [python_exe, "-c", "import certifi; print(certifi.where())"],
-                text=True,
-                timeout=5
-            )
-            cert_path = out.strip()
-        except Exception:
-            cert_path = None
-    if not cert_path:
-        try:
-            import certifi
-            cert_path = certifi.where()
-        except Exception:
-            print("Info: certifi not available; skipping CA environment setup.")
-            return
+    try:
+        # Run python executable from penv to get certifi path
+        out = subprocess.check_output(
+            [python_exe, "-c", "import certifi; print(certifi.where())"],
+            text=True,
+            timeout=5
+        )
+        cert_path = out.strip()
+    except Exception as e:
+        print(f"Error: Failed to obtain certifi path from the virtual environment: {e}")
+        return
+
     # Set environment variables for certificate bundles
     os.environ["CERTIFI_PATH"] = cert_path
     os.environ["SSL_CERT_FILE"] = cert_path

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -452,7 +452,9 @@ def _setup_python_environment_core(env, platform, platformio_dir, should_install
         env.Replace(PYTHONEXE=penv_python)
     
     # check for python binary, exit with error when not found
-    assert os.path.isfile(penv_python), f"Python executable not found: {penv_python}"
+    if not os.path.isfile(penv_python):
+        sys.stderr.write(f"Error: Python executable not found: {penv_python}\n")
+        sys.exit(1)
     
     # Setup Python module search paths
     setup_python_paths(penv_dir)

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -563,7 +563,6 @@ def _install_esptool_from_tl_install(platform, python_exe, uv_executable):
     # Get esptool path from tool-esptoolpy package (provided by tl-install)
     esptool_repo_path = platform.get_package_dir("tool-esptoolpy") or ""
     if not esptool_repo_path or not os.path.isdir(esptool_repo_path):
-        print(f"Warning: tool-esptoolpy package not available, skipping esptool installation")
         return
 
     # Check if esptool is already installed from the correct path

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -430,15 +430,6 @@ def _setup_python_environment_core(env, platform, platformio_dir, should_install
     Returns:
         tuple[str, str]: (Path to penv Python executable, Path to esptool script)
     """
-    # Check Python version requirement
-    if sys.version_info < (3, 10):
-        sys.stderr.write(
-            f"Error: Python 3.10 or higher is required. "
-            f"Current version: {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}\n"
-            f"Please update your Python installation.\n"
-        )
-        sys.exit(1)
-
     penv_dir = str(Path(platformio_dir) / "penv")
     
     # Setup virtual environment if needed

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -127,10 +127,14 @@ def setup_pipenv_in_package(env, penv_dir):
         
         # Validate virtual environment creation
         # Ensure Python executable is available
-        assert os.path.isfile(
-            get_executable_path(penv_dir, "python")
-        ), f"Error: Failed to create a proper virtual environment. Missing the `python` binary! Created with uv: {uv_success}"
-        
+        penv_python = get_executable_path(penv_dir, "python")
+        if not os.path.isfile(penv_python):
+            sys.stderr.write(
+                f"Error: Failed to create a proper virtual environment. "
+                f"Missing the `python` binary at {penv_python}! Created with uv: {uv_success}\n"
+            )
+            sys.exit(1)
+
         return uv_cmd if uv_success else None
     
     return None
@@ -530,9 +534,13 @@ def _setup_pipenv_minimal(penv_dir):
         
         # Validate virtual environment creation
         # Ensure Python executable is available
-        assert os.path.isfile(
-            get_executable_path(penv_dir, "python")
-        ), f"Error: Failed to create a proper virtual environment. Missing the `python` binary! Created with uv: {uv_success}"
+        penv_python = get_executable_path(penv_dir, "python")
+        if not os.path.isfile(penv_python):
+            sys.stderr.write(
+                f"Error: Failed to create a proper virtual environment. "
+                f"Missing the `python` binary at {penv_python}! Created with uv: {uv_success}\n"
+            )
+            sys.exit(1)
         
         return uv_cmd if uv_success else None
     

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -114,16 +114,13 @@ lib_ignore              = wifi
                           Matter
                           Zigbee
                           ESP RainMaker
-custom_sdkconfig        = CONFIG_SPIRAM_MODE_OCT=y
-                          CONFIG_SPIRAM_SPEED_120M=y
-                          CONFIG_LCD_RGB_ISR_IRAM_SAFE=y
+custom_sdkconfig        = CONFIG_LCD_RGB_ISR_IRAM_SAFE=y
                           CONFIG_GDMA_CTRL_FUNC_IN_IRAM=y
                           CONFIG_I2S_ISR_IRAM_SAFE=y
                           CONFIG_GDMA_ISR_IRAM_SAFE=y
                           CONFIG_SPIRAM_XIP_FROM_PSRAM=y
                           CONFIG_SPIRAM_FETCH_INSTRUCTIONS=y
                           CONFIG_SPIRAM_RODATA=y
-                          CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240=y
                           CONFIG_ESP32S3_DATA_CACHE_64KB=y
                           CONFIG_ESP32S3_DATA_CACHE_LINE_64B=y
 custom_component_remove = espressif/esp_hosted

--- a/platform.json
+++ b/platform.json
@@ -51,7 +51,7 @@
       "type": "framework",
       "optional": true,
       "owner": "pioarduino",
-      "version": "https://github.com/pioarduino/esp-idf/releases/download/v5.5.1/esp-idf-v5.5.1.tar.xz"
+      "version": "https://github.com/pioarduino/esp-idf/releases/download/v5.5.1.250929/esp-idf-v5.5.1.tar.xz"
     },
     "toolchain-xtensa-esp-elf": {
       "type": "toolchain",

--- a/platform.json
+++ b/platform.json
@@ -57,15 +57,15 @@
       "type": "toolchain",
       "optional": true,
       "owner": "pioarduino",
-      "package-version": "14.2.0+20241119",
-      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/xtensa-esp-elf-14.2.0_20241119.zip"
+      "package-version": "14.2.0+20250730",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/xtensa-esp-elf-14.2.0_20250730.zip"
     },
     "toolchain-riscv32-esp": {
       "type": "toolchain",
       "optional": true,
       "owner": "pioarduino",
-      "package-version": "14.2.0+20241119",
-      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/riscv32-esp-elf-14.2.0_20241119.zip"
+      "package-version": "14.2.0+20250730",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/riscv32-esp-elf-14.2.0_20250730.zip"
     },
     "toolchain-esp32ulp": {
       "type": "toolchain",

--- a/platform.json
+++ b/platform.json
@@ -18,7 +18,7 @@
     "type": "git",
     "url": "https://github.com/pioarduino/platform-espressif32.git"
   },
-  "version": "55.03.31",
+  "version": "55.03.32",
   "frameworks": {
     "arduino": {
       "script": "builder/frameworks/arduino.py"
@@ -33,13 +33,13 @@
       "type": "framework",
       "optional": true,
       "owner": "espressif",
-      "version": "https://github.com/espressif/arduino-esp32/releases/download/3.3.1/esp32-3.3.1.zip"
+      "version": "https://github.com/espressif/arduino-esp32/releases/download/3.3.2/esp32-3.3.2.tar.xz"
     },
     "framework-arduinoespressif32-libs": {
       "type": "framework",
       "optional": true,
       "owner": "espressif",
-      "version": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v4.zip"
+      "version": "https://github.com/espressif/arduino-esp32/releases/download/3.3.2/esp32-3.3.2-libs.tar.xz"
     },
     "framework-arduino-c2-skeleton-lib": {
       "type": "framework",

--- a/platform.json
+++ b/platform.json
@@ -78,15 +78,15 @@
       "type": "debugger",
       "optional": true,
       "owner": "pioarduino",
-      "package-version": "16.2.0+20250324",
-      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/xtensa-esp-gdb-v16.2_20250324.zip"
+      "package-version": "16.3.0+20250913",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/xtensa-esp-gdb-16.3_20250913.zip"
     },
     "tool-riscv32-esp-elf-gdb": {
       "type": "debugger",
       "optional": true,
       "owner": "pioarduino",
-      "package-version": "16.2.0+20250324",
-      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/riscv32-esp-gdb-v16.2_20250324.zip"
+      "package-version": "16.3.0+20250913",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/riscv32-esp-gdb-16.3_20250913.zip"
     },
     "tool-esptoolpy": {
       "type": "uploader",

--- a/platform.py
+++ b/platform.py
@@ -26,14 +26,14 @@ else:
     del _lzma
 
 import fnmatch
-import os
 import json
+import logging
+import os
 import requests
+import shutil
 import socket
 import subprocess
 import sys
-import shutil
-import logging
 from pathlib import Path
 from typing import Optional, Dict, List, Any, Union
 
@@ -45,8 +45,12 @@ from platformio.package.manager.tool import ToolPackageManager
 
 
 # Import penv_setup functionality
-sys.path.insert(0, str(Path(__file__).parent / "builder"))
-from penv_setup import setup_python_environment, setup_penv_minimal, get_executable_path
+try:
+    from .builder.penv_setup import setup_python_environment, setup_penv_minimal, get_executable_path
+except ImportError:
+    # Fallback for standalone execution
+    sys.path.insert(0, str(Path(__file__).parent / "builder"))
+    from penv_setup import setup_python_environment, setup_penv_minimal, get_executable_path
 
 
 # Constants

--- a/platform.py
+++ b/platform.py
@@ -46,11 +46,11 @@ from platformio.package.manager.tool import ToolPackageManager
 
 # Import penv_setup functionality
 try:
-    from .builder.penv_setup import setup_python_environment, setup_penv_minimal, get_executable_path
+    from .builder.penv_setup import setup_penv_simple, get_executable_path
 except ImportError:
     # Fallback for standalone execution
     sys.path.insert(0, str(Path(__file__).parent / "builder"))
-    from penv_setup import setup_python_environment, setup_penv_minimal, get_executable_path
+    from penv_setup import setup_penv_simple, get_executable_path
 
 
 # Constants
@@ -740,14 +740,9 @@ class Espressif32Platform(PlatformBase):
         
         # This should not happen, but provide fallback
         logger.warning("Penv not set up in configure_default_packages, setting up now")
-        config = ProjectConfig.get_instance()
-        core_dir = config.get("platformio", "core_dir")
         
-        python_exe, esptool_binary_path = setup_python_environment(env, self, core_dir)
-        self._penv_python = python_exe
-        self._esptool_path = esptool_binary_path
-        
-        return python_exe, esptool_binary_path
+        # Use the centralized setup method
+        return self.setup_python_env(env)
 
     def configure_default_packages(self, variables: Dict, targets: List[str]) -> Any:
         """Main configuration method with optimized package management."""
@@ -768,8 +763,8 @@ class Espressif32Platform(PlatformBase):
             config = ProjectConfig.get_instance()
             core_dir = config.get("platformio", "core_dir")
             
-            # Setup penv using minimal function (no SCons dependencies, esptool from tl-install)
-            penv_python, esptool_path = setup_penv_minimal(self, core_dir, install_esptool=True)
+            # Setup penv using simple function (no SCons dependencies, esptool from tl-install)
+            penv_python, esptool_path = setup_penv_simple(self, core_dir)
             
             # Store both for later use
             self._penv_python = penv_python

--- a/platform.py
+++ b/platform.py
@@ -405,7 +405,7 @@ class Espressif32Platform(PlatformBase):
             'tool_exists': Path(paths['tool_path']).exists()
         }
 
-    def _run_idf_tools_install(self, tools_json_path: str, idf_tools_path: str, penv_python: str = None) -> bool:
+    def _run_idf_tools_install(self, tools_json_path: str, idf_tools_path: str, penv_python: Optional[str] = None) -> bool:
         """
         Execute idf_tools.py install command.
         Note: No timeout is set to allow installations to complete on slow networks.
@@ -500,7 +500,7 @@ class Espressif32Platform(PlatformBase):
         logger.debug(f"Tool {tool_name} already configured")
         return True
 
-    def _install_with_idf_tools(self, tool_name: str, paths: Dict[str, str], penv_python: str = None) -> bool:
+    def _install_with_idf_tools(self, tool_name: str, paths: Dict[str, str], penv_python: Optional[str] = None) -> bool:
         """Install tool using idf_tools.py installation method."""
         if not self._run_idf_tools_install(
             paths['tools_json_path'], paths['idf_tools_path'], penv_python
@@ -521,7 +521,7 @@ class Espressif32Platform(PlatformBase):
         logger.info(f"Tool {tool_name} successfully installed")
         return True
 
-    def _handle_existing_tool(self, tool_name: str, paths: Dict[str, str], penv_python: str = None) -> bool:
+    def _handle_existing_tool(self, tool_name: str, paths: Dict[str, str], penv_python: Optional[str] = None) -> bool:
         """Handle already installed tools with version checking."""
         if self._check_tool_version(tool_name):
             # Version matches, use tool

--- a/platform.py
+++ b/platform.py
@@ -740,18 +740,6 @@ class Espressif32Platform(PlatformBase):
             # Update SCons environment with centrally configured Python executable
             env.Replace(PYTHONEXE=self._penv_python)
             return self._penv_python, self._esptool_path
-        
-        # This should not happen, but provide fallback
-        logger.warning("Penv not set up in configure_default_packages, setting up now")
-        
-        # Fallback to minimal setup if centralized configuration failed
-        config = ProjectConfig.get_instance()
-        core_dir = config.get("platformio", "core_dir")
-        penv_python, esptool_path = setup_penv_minimal(self, core_dir, install_esptool=True)
-        self._penv_python = penv_python
-        self._esptool_path = esptool_path
-        env.Replace(PYTHONEXE=penv_python)
-        return penv_python, esptool_path
 
     def configure_default_packages(self, variables: Dict, targets: List[str]) -> Any:
         """Main configuration method with optimized package management."""

--- a/platform.py
+++ b/platform.py
@@ -428,13 +428,15 @@ class Espressif32Platform(PlatformBase):
             logger.info(f"Installing tools via idf_tools.py (this may take several minutes)...")
             result = subprocess.run(
                 cmd,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
                 check=False
             )
 
             if result.returncode != 0:
-                logger.error("idf_tools.py installation failed")
+                tail = (result.stderr or result.stdout or "").strip()[-1000:]
+                logger.error("idf_tools.py installation failed (rc=%s). Tail:\n%s", result.returncode, tail)
                 return False
 
             logger.debug("idf_tools.py executed successfully")

--- a/platform.py
+++ b/platform.py
@@ -26,6 +26,7 @@ else:
     del _lzma
 
 import fnmatch
+import importlib.util
 import json
 import logging
 import os
@@ -45,12 +46,14 @@ from platformio.package.manager.tool import ToolPackageManager
 
 
 # Import penv_setup functionality
-try:
-    from .builder.penv_setup import setup_penv_minimal, get_executable_path
-except ImportError:
-    # Fallback for standalone execution
-    sys.path.insert(0, str(Path(__file__).parent / "builder"))
-    from penv_setup import setup_penv_minimal, get_executable_path
+# Import penv_setup functionality using explicit module loading
+penv_setup_path = Path(__file__).parent / "builder" / "penv_setup.py"
+spec = importlib.util.spec_from_file_location("penv_setup", str(penv_setup_path))
+penv_setup_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(penv_setup_module)
+
+setup_penv_minimal = penv_setup_module.setup_penv_minimal
+get_executable_path = penv_setup_module.get_executable_path
 
 
 # Constants

--- a/platform.py
+++ b/platform.py
@@ -42,7 +42,12 @@ from platformio.public import PlatformBase, to_unix_path
 from platformio.proc import get_pythonexe_path
 from platformio.project.config import ProjectConfig
 from platformio.package.manager.tool import ToolPackageManager
-from .builder.penv_setup import setup_python_environment
+
+
+# Import penv_setup functionality
+sys.path.insert(0, str(Path(__file__).parent / "builder"))
+from penv_setup import setup_python_environment
+
 
 # Constants
 DEFAULT_DEBUG_SPEED = "5000"

--- a/platform.py
+++ b/platform.py
@@ -495,7 +495,7 @@ class Espressif32Platform(PlatformBase):
         # Case 2: Tool already installed, version check
         if (status['has_idf_tools'] and status['has_piopm'] and
                 not status['has_tools_json']):
-            return self._handle_existing_tool(tool_name, paths, penv_python)
+            return self._handle_existing_tool(tool_name, paths)
 
         logger.debug(f"Tool {tool_name} already configured")
         return True
@@ -521,7 +521,7 @@ class Espressif32Platform(PlatformBase):
         logger.info(f"Tool {tool_name} successfully installed")
         return True
 
-    def _handle_existing_tool(self, tool_name: str, paths: Dict[str, str], penv_python: Optional[str] = None) -> bool:
+    def _handle_existing_tool(self, tool_name: str, paths: Dict[str, str]) -> bool:
         """Handle already installed tools with version checking."""
         if self._check_tool_version(tool_name):
             # Version matches, use tool

--- a/platform.py
+++ b/platform.py
@@ -46,7 +46,7 @@ from platformio.package.manager.tool import ToolPackageManager
 
 # Import penv_setup functionality
 sys.path.insert(0, str(Path(__file__).parent / "builder"))
-from penv_setup import setup_python_environment, setup_penv_minimal
+from penv_setup import setup_python_environment, setup_penv_minimal, install_esptool_into_penv
 
 
 # Constants
@@ -756,20 +756,29 @@ class Espressif32Platform(PlatformBase):
         frameworks = list(variables.get("pioframework", []))  # Create copy
 
         try:
-            # FIRST: Setup Python virtual environment completely
+            # FIRST: Install required packages
+            self._configure_installer()
+            self._install_esptool_package()
+            
+            # THEN: Setup Python virtual environment completely
             config = ProjectConfig.get_instance()
             core_dir = config.get("platformio", "core_dir")
             
-            # Setup penv using minimal function (no SCons dependencies)
-            penv_python, esptool_path = setup_penv_minimal(self, core_dir)
+            # Setup penv using minimal function (no SCons dependencies, skip esptool for now)
+            penv_python, esptool_path = setup_penv_minimal(self, core_dir, install_esptool=False)
             
-            # Store both for later use
+            # Store penv python for later use
             self._penv_python = penv_python
-            self._esptool_path = esptool_path
             
             # Configuration steps (now with penv available)
-            self._configure_installer()
-            self._install_esptool_package()
+            # Install esptool into penv after tool-esptoolpy package is available
+            install_esptool_into_penv(self, penv_python)
+            
+            # Update esptool path
+            from pathlib import Path
+            from .builder.penv_setup import get_executable_path
+            penv_dir = str(Path(penv_python).parent.parent)
+            self._esptool_path = get_executable_path(penv_dir, "esptool")
             self._configure_arduino_framework(frameworks)
             self._configure_espidf_framework(frameworks, variables, board_config, mcu)
             self._configure_mcu_toolchains(mcu, variables, targets)

--- a/platform.py
+++ b/platform.py
@@ -741,8 +741,14 @@ class Espressif32Platform(PlatformBase):
         # This should not happen, but provide fallback
         logger.warning("Penv not set up in configure_default_packages, setting up now")
         
-        # Use the centralized setup method
-        return self.setup_python_env(env)
+        # Use centralized minimal setup as a fallback and propagate into SCons
+        config = ProjectConfig.get_instance()
+        core_dir = config.get("platformio", "core_dir")
+        penv_python, esptool_path = setup_penv_minimal(self, core_dir, install_esptool=True)
+        self._penv_python = penv_python
+        self._esptool_path = esptool_path
+        env.Replace(PYTHONEXE=penv_python)
+        return penv_python, esptool_path
 
     def configure_default_packages(self, variables: Dict, targets: List[str]) -> Any:
         """Main configuration method with optimized package management."""

--- a/platform.py
+++ b/platform.py
@@ -45,7 +45,6 @@ from platformio.project.config import ProjectConfig
 from platformio.package.manager.tool import ToolPackageManager
 
 
-# Import penv_setup functionality
 # Import penv_setup functionality using explicit module loading
 penv_setup_path = Path(__file__).parent / "builder" / "penv_setup.py"
 spec = importlib.util.spec_from_file_location("penv_setup", str(penv_setup_path))

--- a/platform.py
+++ b/platform.py
@@ -46,7 +46,7 @@ from platformio.package.manager.tool import ToolPackageManager
 
 # Import penv_setup functionality
 sys.path.insert(0, str(Path(__file__).parent / "builder"))
-from penv_setup import setup_python_environment, setup_penv_minimal, install_esptool_into_penv
+from penv_setup import setup_python_environment, setup_penv_minimal, get_executable_path
 
 
 # Constants
@@ -764,21 +764,14 @@ class Espressif32Platform(PlatformBase):
             config = ProjectConfig.get_instance()
             core_dir = config.get("platformio", "core_dir")
             
-            # Setup penv using minimal function (no SCons dependencies, skip esptool for now)
-            penv_python, esptool_path = setup_penv_minimal(self, core_dir, install_esptool=False)
+            # Setup penv using minimal function (no SCons dependencies, esptool from tl-install)
+            penv_python, esptool_path = setup_penv_minimal(self, core_dir, install_esptool=True)
             
-            # Store penv python for later use
+            # Store both for later use
             self._penv_python = penv_python
+            self._esptool_path = esptool_path
             
             # Configuration steps (now with penv available)
-            # Install esptool into penv after tool-esptoolpy package is available
-            install_esptool_into_penv(self, penv_python)
-            
-            # Update esptool path
-            from pathlib import Path
-            from .builder.penv_setup import get_executable_path
-            penv_dir = str(Path(penv_python).parent.parent)
-            self._esptool_path = get_executable_path(penv_dir, "esptool")
             self._configure_arduino_framework(frameworks)
             self._configure_espidf_framework(frameworks, variables, board_config, mcu)
             self._configure_mcu_toolchains(mcu, variables, targets)

--- a/platform.py
+++ b/platform.py
@@ -46,11 +46,11 @@ from platformio.package.manager.tool import ToolPackageManager
 
 # Import penv_setup functionality
 try:
-    from .builder.penv_setup import setup_penv_simple, get_executable_path
+    from .builder.penv_setup import setup_penv_minimal, get_executable_path
 except ImportError:
     # Fallback for standalone execution
     sys.path.insert(0, str(Path(__file__).parent / "builder"))
-    from penv_setup import setup_penv_simple, get_executable_path
+    from penv_setup import setup_penv_minimal, get_executable_path
 
 
 # Constants
@@ -763,8 +763,8 @@ class Espressif32Platform(PlatformBase):
             config = ProjectConfig.get_instance()
             core_dir = config.get("platformio", "core_dir")
             
-            # Setup penv using simple function (no SCons dependencies, esptool from tl-install)
-            penv_python, esptool_path = setup_penv_simple(self, core_dir)
+            # Setup penv using minimal function (no SCons dependencies, esptool from tl-install)
+            penv_python, esptool_path = setup_penv_minimal(self, core_dir, install_esptool=True)
             
             # Store both for later use
             self._penv_python = penv_python

--- a/platform.py
+++ b/platform.py
@@ -761,15 +761,10 @@ class Espressif32Platform(PlatformBase):
             config = ProjectConfig.get_instance()
             core_dir = config.get("platformio", "core_dir")
             
-            # Create a dummy env object for setup_python_environment
-            # This is needed because configure_default_packages doesn't receive an env parameter
-            from SCons.Script import DefaultEnvironment
-            temp_env = DefaultEnvironment()
-            
-            penv_python, _ = setup_python_environment(temp_env, self, core_dir)
-            
-            # Store penv_python for use in tool installations
-            self._penv_python = penv_python
+            # Setup penv without SCons environment (we'll handle that later in setup_python_env)
+            # For now, just prepare the penv directory and mark that we need to set it up
+            self._core_dir = core_dir
+            self._penv_setup_needed = True
             
             # Configuration steps (now with penv available)
             self._configure_installer()

--- a/platform.py
+++ b/platform.py
@@ -42,12 +42,7 @@ from platformio.public import PlatformBase, to_unix_path
 from platformio.proc import get_pythonexe_path
 from platformio.project.config import ProjectConfig
 from platformio.package.manager.tool import ToolPackageManager
-
-# Import penv_setup functionality
-import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).parent / "builder"))
-from penv_setup import setup_python_environment
+from .builder.penv_setup import setup_python_environment
 
 # Constants
 DEFAULT_DEBUG_SPEED = "5000"

--- a/platform.py
+++ b/platform.py
@@ -43,6 +43,12 @@ from platformio.proc import get_pythonexe_path
 from platformio.project.config import ProjectConfig
 from platformio.package.manager.tool import ToolPackageManager
 
+# Import penv_setup functionality
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent / "builder"))
+from penv_setup import setup_python_environment
+
 # Constants
 DEFAULT_DEBUG_SPEED = "5000"
 DEFAULT_APP_OFFSET = "0x10000"
@@ -713,6 +719,16 @@ class Espressif32Platform(PlatformBase):
 
         if "downloadfs" in targets:
             self._install_filesystem_tool(filesystem, for_download=True)
+
+    def setup_python_env(self, env):
+        """Setup Python virtual environment and return executable paths."""
+        config = ProjectConfig.get_instance()
+        core_dir = config.get("platformio", "core_dir")
+        
+        # Setup Python virtual environment and get executable paths
+        python_exe, esptool_binary_path = setup_python_environment(env, self, core_dir)
+        
+        return python_exe, esptool_binary_path
 
     def configure_default_packages(self, variables: Dict, targets: List[str]) -> Any:
         """Main configuration method with optimized package management."""


### PR DESCRIPTION


## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Arduino build flow: automatic component restore, Windows include-path shortening, and delegated Arduino‑IDF library build when Arduino is selected without ESP‑IDF.
  * Minimal virtualenv setup path and support for loading board-specific configuration scripts.

* **Improvements**
  * Centralized Python/esptool environment across install/build flows, per-package installs, longer timeouts, clearer logging and stronger error handling.
  * ESP‑IDF config generation improved with board-specific sdkconfig flags and linker preprocessing across versions.
  * Platform toolchain and debugger package targets updated; example SDK config entries adjusted.

* **Chores**
  * Import reorders and comment/header wording refinements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->