### PR TITLE
Eliminate fallback for Python environment setup

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -740,18 +740,6 @@ class Espressif32Platform(PlatformBase):
             # Update SCons environment with centrally configured Python executable
             env.Replace(PYTHONEXE=self._penv_python)
             return self._penv_python, self._esptool_path
-        
-        # This should not happen, but provide fallback
-        logger.warning("Penv not set up in configure_default_packages, setting up now")
-        
-        # Fallback to minimal setup if centralized configuration failed
-        config = ProjectConfig.get_instance()
-        core_dir = config.get("platformio", "core_dir")
-        penv_python, esptool_path = setup_penv_minimal(self, core_dir, install_esptool=True)
-        self._penv_python = penv_python
-        self._esptool_path = esptool_path
-        env.Replace(PYTHONEXE=penv_python)
-        return penv_python, esptool_path
 
     def configure_default_packages(self, variables: Dict, targets: List[str]) -> Any:
         """Main configuration method with optimized package management."""


### PR DESCRIPTION
Removed fallback setup for Python environment in platform configuration.

## Description:

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest develop branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [ ] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
