### PR TITLE
Do not display errors during building after esp-idf-size made breaking change in v2

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -611,7 +611,7 @@ def firmware_metrics(target, source, env):
         return
 
     try:        
-        cmd = [PYTHON_EXE, "-m", "esp_idf_size", "--ng"]
+        cmd = [PYTHON_EXE, "-m", "esp_idf_size", ""]
         
         # Parameters from platformio.ini
         extra_args = env.GetProjectOption("custom_esp_idf_size_args", "")


### PR DESCRIPTION
Fix default arguments to not include --ng as it is now the default since v2.0.0: https://github.com/espressif/esp-idf-size/releases/tag/v2.0.0

## Description:

esp-idf-size made a breaking change by not allowing the default arguments of --ng anymore; building from esphome produced errors in the logs.

## Checklist:
  - [X] The pull request is done against the latest develop branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [X] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
