### PR TITLE
Fixed firmware metrics display issue on Windows

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -596,8 +596,8 @@ def firmware_metrics(target, source, env):
         source: SCons source
         env: SCons environment object
     """
-    if terminal_cp != "utf-8":
-        print("Firmware metrics can not be shown. Set the terminal codepage to \"utf-8\"")
+    if terminal_cp not in ["utf-8", "cp1252", "cp437", "cp850", "windows-1252", "cp65001"]:
+        print("Firmware metrics can not be shown. Set the terminal codepage to \"utf-8\" or one of cp1252/cp437/cp65001/cp850 on Windows.")
         return
 
     map_file = str(Path(env.subst("$BUILD_DIR")) / (env.subst("$PROGNAME") + ".map"))


### PR DESCRIPTION
## Description:
The terminal would fail to display firmware metrics (memory type usage summary) on windows due to following error:

`Building in release mode
Linking .pioenvs\esp32-mq2\firmware.elf
Firmware metrics can not be shown. Set the terminal codepage to "utf-8"`

Relavant info:
utf-8 codepage in terminal can selected using `chcp <code>` command, where code is 65001 for utf-8.
Win11's also has a "Beta: Use Unicode UTF-8 for worldwide language support" checkbox.

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
