### PR TITLE
HybridCompile: replace move operations with copy

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2596,7 +2596,7 @@ if ("arduino" in env.subst("$PIOFRAMEWORK")) and ("espidf" not in env.subst("$PI
                 # Gracefully handle missing source files (e.g., PSRAM libs in non-PSRAM builds)
                 # This is expected when copying variant-specific libraries
                 pass
-            except Exception:
+            except Exception as e:
                 print(f"Warning: Failed to copy {src} to {dst}: {e}")
         env_build = str(Path(env["PROJECT_BUILD_DIR"]) / env["PIOENV"])
         sdkconfig_h_path = str(Path(env_build) / "config" / "sdkconfig.h")


### PR DESCRIPTION
## Description:

dont delete exiting *.a libs to avoid linker errors with unused libs

**Related issue (if applicable):** fixes #336

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made library copying during Arduino + ESP-IDF builds more robust to missing or variant-specific files, avoiding build failures.
  * Switched to non-fatal warnings on copy errors and standardized copy behavior across ESP32 variants to reduce integration interruptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->