### PR TITLE
custom_sdkconfig is already set in boards manifest 

### DIFF
--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -539,9 +539,6 @@ flag_custom_component_add = False
 flag_lib_ignore = False
 flag_lto = False
 
-if mcu == "esp32c2" or mcu == "esp32c61":
-    flag_custom_sdkconfig = True
-
 # pio lib_ignore check
 if config.has_option(current_env_section, "lib_ignore"):
     flag_lib_ignore = True


### PR DESCRIPTION
no need to set in arduino.py

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
