### PR TITLE
fix wrong flash_size and maximum_size

### DIFF
--- a/boards/esp32-s3-devkitc1-n16r2.json
+++ b/boards/esp32-s3-devkitc1-n16r2.json
@@ -44,7 +44,7 @@
   ],
   "name": "Espressif ESP32-S3-DevKitC-1-N16R2 (16 MB Flash Quad, 2 MB PSRAM Quad)",
   "upload": {
-    "flash_size": "8MB",
+    "flash_size": "16MB",
     "maximum_ram_size": 327680,
     "maximum_size": 16777216,
     "require_upload_port": true,

--- a/boards/esp32-s3-devkitc1-n4r2.json
+++ b/boards/esp32-s3-devkitc1-n4r2.json
@@ -44,7 +44,7 @@
   ],
   "name": "Espressif ESP32-S3-DevKitC-1-N4R2 (4 MB Flash Quad, 2 MB PSRAM Quad)",
   "upload": {
-    "flash_size": "8MB",
+    "flash_size": "4MB",
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,

--- a/boards/esp32-s3-devkitc1-n4r8.json
+++ b/boards/esp32-s3-devkitc1-n4r8.json
@@ -44,7 +44,7 @@
   ],
   "name": "Espressif ESP32-S3-DevKitC-1-N4R8 (4 MB Flash Quad, 8 MB PSRAM Octal)",
   "upload": {
-    "flash_size": "8MB",
+    "flash_size": "4MB",
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,

--- a/boards/labplus_mpython.json
+++ b/boards/labplus_mpython.json
@@ -23,7 +23,7 @@
   ],
   "name": "Labplus mPython",
   "upload": {
-    "flash_size": "8MB",
+    "flash_size": "4MB",
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,

--- a/boards/um_squixl.json
+++ b/boards/um_squixl.json
@@ -40,7 +40,7 @@
   "upload": {
     "flash_size": "16MB",
     "maximum_ram_size": 327680,
-    "maximum_size": 8388608,
+    "maximum_size": 16777216,
     "require_upload_port": true,
     "speed": 460800
   },


### PR DESCRIPTION
## Description:
fixes the flash_size and maximum_size for some boards.

**Related issue (if applicable):fixes #375 

## Checklist:
  - [ x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
