### PR TITLE
Add Python 3.14 support

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2050,7 +2050,10 @@ def install_python_deps():
         # https://github.com/platformio/platform-espressif32/issues/635
         "cryptography": "~=44.0.0",
         "pyparsing": ">=3.1.0,<4",
-        "idf-component-manager": "~=2.4",
+        # Python 3.14 requires pydantic>=2.12 for pre-built pydantic-core wheels
+        "pydantic": ">=2.12.5",
+        "pydantic-core": ">=2.41.5",
+        "idf-component-manager": ">=2.4",
         "esp-idf-kconfig": "~=2.5.0"
     }
 

--- a/platform.py
+++ b/platform.py
@@ -15,10 +15,10 @@
 # Python Version Check
 import sys
 
-if not ((3, 10) <= sys.version_info < (3, 14)):
-    print("ERROR: Python version must be between 3.10 and 3.13.", file=sys.stderr)
+if not ((3, 10) <= sys.version_info < (3, 15)):
+    print("ERROR: Python version must be between 3.10 and 3.14.", file=sys.stderr)
     print(f"Current Python version: {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}", file=sys.stderr)
-    print("Supported versions: 3.10, 3.11, 3.12, 3.13", file=sys.stderr)
+    print("Supported versions: 3.10, 3.11, 3.12, 3.13, 3.14", file=sys.stderr)
     raise SystemExit(1)
 
 # LZMA support check


### PR DESCRIPTION
Allows building with Python 3.14.

The main issue is that older pydantic versions (2.11.x) pull in pydantic-core versions without pre-built 3.14 wheels. Building from source fails because pyo3-ffi doesn't handle Python 3.14's Unicode API changes yet (at least not in the pinned version).

Fixed by pinning pydantic>=2.12.5 which uses pydantic-core>=2.41.5 - this version has wheels for all supported Python versions (3.10-3.14).

Tested with Python 3.14.2 on ESP-IDF 5.5.1.

- [x] I accept the CLA

PS: Sorry about the PR template btw, I created this via gh and that overrides the template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended Python version support to include Python 3.14 for compatibility with the latest Python release.
  * Updated package dependencies to ensure optimal compatibility and stability with component management and validation libraries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->