### PR TITLE
feat(board): Add board files for YB-ESP32-S3-AMP and YB-ESP32-S3-DAC

### DIFF
--- a/boards/yb_esp32s3_amp.json
+++ b/boards/yb_esp32s3_amp.json
@@ -1,0 +1,56 @@
+{
+  "build": {
+    "arduino":{
+      "partitions": "default_8MB.csv",
+      "memory_type": "qio_qspi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_YB_ESP32S3_AMP",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ],
+      [
+        "0x1A86",
+        "0x55D3"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "yb_esp32s3_amp"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "YelloByte YB-ESP32-S3-AMP",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://github.com/yellobyte/YB-ESP32-S3-AMP",
+  "vendor": "YelloByte"
+}

--- a/boards/yb_esp32s3_dac.json
+++ b/boards/yb_esp32s3_dac.json
@@ -1,0 +1,56 @@
+{
+  "build": {
+    "arduino":{
+      "partitions": "default_8MB.csv",
+      "memory_type": "qio_qspi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_YB_ESP32S3_DAC",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ],
+      [
+        "0x1A86",
+        "0x55D3"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "yb_esp32s3_dac"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "YelloByte YB-ESP32-S3-DAC",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://github.com/yellobyte/YB-ESP32-S3-DAC",
+  "vendor": "YelloByte"
+}


### PR DESCRIPTION
## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)

##Description:
1) Two new boards to be released soon: YB-ESP32-S3-AMP and YB-ESP32-S3-DAC.
2) The board's variant files have already been merged with Espressif Arduino ESP32 Core v3.3.6:
  https://github.com/espressif/arduino-esp32/tree/master/variants/yb_esp32s3_amp
  https://github.com/espressif/arduino-esp32/tree/master/variants/yb_esp32s3_dac
3) Pre-commit on both *.json board files without errors.

Thanks & Regards
yellobyte
