### PR TITLE
set uv cache dir to `.platformio/.cache` folder for easy clean up

### DIFF
--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -610,7 +610,7 @@ def _install_esptool_from_tl_install(platform, python_exe, uv_executable, uv_cac
         platform: PlatformIO platform object  
         python_exe (str): Path to Python executable in virtual environment
         uv_executable (str): Path to uv executable
-        uv_cache_dir: Optional path to uv cache directory (e.g. inside build folder)
+        uv_cache_dir: Optional path to uv cache directory
     
     Raises:
         SystemExit: If esptool installation fails or package directory not found


### PR DESCRIPTION
## Description:

to try to recover better from broken install attempts when Github is not reachable and broken? leftovers are stored in uv cache.

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional UV cache directory configuration, enabling customizable caching for Python dependency and esptool installations to improve build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->