### PR TITLE
Add --no-cache-dir to pip fallback when installing uv

### DIFF
--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -274,7 +274,7 @@ def install_python_deps(python_exe, external_uv_executable, uv_cache_dir=None):
             # Fallback to pip to install uv into penv
             try:
                 subprocess.check_call(
-                    [python_exe, "-m", "pip", "install", "uv>=0.1.0", "--quiet"],
+                    [python_exe, "-m", "pip", "install", "uv>=0.1.0", "--quiet", "--no-cache-dir"],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.STDOUT,
                     timeout=300


### PR DESCRIPTION
## Summary
- Adds `--no-cache-dir` flag to the pip fallback path for installing uv into the penv
- The pip cache lock can be held by another process (e.g., a concurrent build, IDE background task), causing the install to hang silently for extended periods
- Since this is a one-time bootstrap of a small package (`uv`), bypassing the cache avoids lock contention with negligible download cost

## Test plan
- [ ] Verify pip fallback path installs uv successfully with `--no-cache-dir`
- [ ] Verify normal uv-based install path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)