### PR TITLE
Add Seeed XIAO ESP32C5 board definition

### DIFF
--- a/boards/seeed_xiao_esp32c5.json
+++ b/boards/seeed_xiao_esp32c5.json
@@ -1,7 +1,6 @@
 {
   "build": {
     "partitions": "default_8MB.csv",
-    "memory_type": "qio_qspi",
     "core": "esp32",
     "extra_flags": [
       "-DARDUINO_XIAO_ESP32C5",
@@ -12,7 +11,6 @@
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "qio",
-    "psram_type": "qspi",
     "hwids": [
       [
         "0x303a",

--- a/boards/seeed_xiao_esp32c5.json
+++ b/boards/seeed_xiao_esp32c5.json
@@ -1,0 +1,48 @@
+{
+  "build": {
+    "partitions": "default_8MB.csv",
+    "memory_type": "qio_qspi",
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_XIAO_ESP32C5",
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "psram_type": "qspi",
+    "hwids": [
+      [
+        "0x303a",
+        "0x1001"
+      ] 
+    ],
+    "mcu": "esp32c5",
+    "variant": "XIAO_ESP32C5"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "zigbee",
+    "thread"
+  ],
+  "debug": {
+    "openocd_target": "esp32c5.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Seeed Studio XIAO ESP32C5",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://wiki.seeedstudio.com/xiao_esp32c5_getting_started/",
+  "vendor": "Seeed Studio"
+}


### PR DESCRIPTION
## Description:

Corrected Seeed XIAO ESP32C5 board definition as per [PR 393](https://github.com/pioarduino/platform-espressif32/pull/393).  Sorry for raising that PR on the main branch and thank you for the help.

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
