### PR TITLE
Adjust flash size from 2M to 4M for Arduino MMU compatibility

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -421,7 +421,7 @@ def HandleArduinoIDFsettings(env):
             flash_size = board.get("upload", {}).get("flash_size", None)
 
         if flash_size == "2MB":
-            print(f"Info: Detected 2MB flash size setting, override to 4MB for Arduino MMU page size compatibility")
+            print("Info: Detected 2MB flash size setting, override to 4MB for Arduino MMU page size compatibility")
             flash_size = "4MB"
 
         if flash_size:

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -419,7 +419,11 @@ def HandleArduinoIDFsettings(env):
         # Fallback to board.json manifest
         if not flash_size:
             flash_size = board.get("upload", {}).get("flash_size", None)
-        
+
+        if flash_size == "2MB":
+            print(f"Info: Detected 2MB flash size setting, override to 4MB for Arduino MMU page size compatibility")
+            flash_size = "4MB"
+
         if flash_size:
             # Configure both string and boolean flash size formats
             # Disable other flash size options first


### PR DESCRIPTION
## Description:

fix for crashing ESP32-C2 2MB and all other ESP32x variants with 2MB in Hybrid Compile mode.

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flash memory configuration handling to ensure proper compatibility with specific board setups requiring adjusted memory allocation initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->