### PR TITLE
Update featheresp32-s2 partition ref for Arduino ESP32 3.x

### DIFF
--- a/boards/featheresp32-s2.json
+++ b/boards/featheresp32-s2.json
@@ -1,8 +1,7 @@
 {
   "build": {
     "arduino": {
-      "partitions": "tinyuf2-partitions-4MB.csv",
-      "custom_bootloader": "bootloader-tinyuf2.bin"
+      "partitions": "tinyuf2-partitions-4MB.csv"
     },
     "core": "esp32",
     "extra_flags": [
@@ -43,6 +42,10 @@
   "upload": {
     "arduino": {
       "flash_extra_images": [
+        [
+          "0x0",
+          "variants/adafruit_feather_esp32s2/bootloader-tinyuf2.bin"
+        ],
         [
           "0x2d0000",
           "variants/adafruit_feather_esp32s2/tinyuf2.bin"

--- a/boards/featheresp32-s2.json
+++ b/boards/featheresp32-s2.json
@@ -1,7 +1,8 @@
 {
   "build": {
     "arduino": {
-      "partitions": "partitions-4MB-tinyuf2.csv"
+      "partitions": "tinyuf2-partitions-4MB.csv",
+      "custom_bootloader": "bootloader-tinyuf2.bin"
     },
     "core": "esp32",
     "extra_flags": [

--- a/boards/featheresp32-s2.json
+++ b/boards/featheresp32-s2.json
@@ -1,7 +1,8 @@
 {
   "build": {
     "arduino": {
-      "partitions": "tinyuf2-partitions-4MB.csv"
+      "partitions": "tinyuf2-partitions-4MB.csv",
+      "custom_bootloader": "bootloader-tinyuf2.bin"
     },
     "core": "esp32",
     "extra_flags": [
@@ -42,10 +43,6 @@
   "upload": {
     "arduino": {
       "flash_extra_images": [
-        [
-          "0x0",
-          "variants/adafruit_feather_esp32s2/bootloader-tinyuf2.bin"
-        ],
         [
           "0x2d0000",
           "variants/adafruit_feather_esp32s2/tinyuf2.bin"


### PR DESCRIPTION
## Description:

`partitions-4MB-tinyuf2.csv` was removed from the `adafruit_feather_esp32s2` variant dir in `framework-arduinoespressif32` 3.x . The equivalent file is `tinyuf2-partitions-4MB.csv` in `tools/partitions/`.

Add `custom_bootloader` to preserve tinyuf2 bootloader selection, which the build script would otherwise revert based on the old filename suffix.

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
