### PR TITLE
Correct URL in xiao esp32c6 boardfile

### DIFF
--- a/boards/seeed_xiao_esp32c6.json
+++ b/boards/seeed_xiao_esp32c6.json
@@ -43,6 +43,6 @@
     "require_upload_port": true,
     "speed": 460800
   },
-  "url": "https://wiki.seeedstudio.com/XIAO_ESP32C6_Getting_Started/",
+  "url": "https://wiki.seeedstudio.com/xiao_esp32c6_getting_started/",
   "vendor": "Seeed Studio"
 }


### PR DESCRIPTION
Correct xiao esp32c6 URL to https://wiki.seeedstudio.com/xiao_esp32c6_getting_started/