### PR TITLE
feature: generate factory firmware for initial flashing

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -1645,7 +1645,7 @@ def esp32_create_combined_bin(source, target, env):
             [esptool, *cmd], check=False, capture_output=True, text=True
         )
         if result.returncode == 0:
-            print("\nSuccessfully created combined binary image.")
+            print("Successfully created combined binary image.")
         else:
             print(f"\nesptool merge-bin failed (exit code {result.returncode})")
             if result.stderr:

--- a/builder/main.py
+++ b/builder/main.py
@@ -1902,23 +1902,6 @@ env.AddPlatformTarget(
     "Download and extract filesystem from device",
 )
 
-# Target: Upload combined factory binary at offset 0
-env.AddPlatformTarget(
-    "upload_factory",
-    target_firm,
-    [
-        env.VerboseAction(esp32_create_combined_bin, "Creating combined factory binary..."),
-        env.VerboseAction(BeforeUpload, "Looking for upload port..."),
-        env.VerboseAction(
-            '$UPLOADER --chip %s --port "$UPLOAD_PORT" --baud $UPLOAD_SPEED'
-            ' write-flash 0x0 "$BUILD_DIR/${PROGNAME}.factory.bin"'
-            % mcu,
-            "Uploading factory binary $BUILD_DIR/${PROGNAME}.factory.bin",
-        ),
-    ],
-    "Upload Factory Image",
-)
-
 # Target: Erase Flash and Upload
 env.AddPlatformTarget(
     "erase_upload",

--- a/builder/main.py
+++ b/builder/main.py
@@ -1627,7 +1627,7 @@ def esp32_create_combined_bin(source, target, env):
         "--flash-size", flash_size,
     ]
 
-    print(f"\nCreating combined binary {factory_name} with :")
+    print(f"\nCreating combined binary {os.path.basename(factory_name)} with:")
     print("    Offset   | File")
 
     for image in env.get("FLASH_EXTRA_IMAGES", []):

--- a/builder/main.py
+++ b/builder/main.py
@@ -1627,7 +1627,7 @@ def esp32_create_combined_bin(source, target, env):
         "--flash-size", flash_size,
     ]
 
-    print(f"\nCreating combined binary {os.path.basename(factory_name)} with:")
+    print(f"\nCreating binary \"{os.path.basename(factory_name)}\" with:")
     print("    Offset   | File")
 
     for image in env.get("FLASH_EXTRA_IMAGES", []):

--- a/builder/main.py
+++ b/builder/main.py
@@ -1627,7 +1627,7 @@ def esp32_create_combined_bin(source, target, env):
         "--flash-size", flash_size,
     ]
 
-    print("\nCreating combined factory binary...")
+    print(f"\nCreating combined binary {factory_name} with :")
     print("    Offset   | File")
 
     for image in env.get("FLASH_EXTRA_IMAGES", []):

--- a/builder/main.py
+++ b/builder/main.py
@@ -1642,7 +1642,7 @@ def esp32_create_combined_bin(source, target, env):
     esptool = esptool_binary_path
     try:
         result = subprocess.run(
-            [esptool] + cmd, check=False, capture_output=True, text=True
+            [esptool, *cmd], check=False, capture_output=True, text=True
         )
         if result.returncode == 0:
             print(f"\nSuccessfully created: {factory_name}")

--- a/builder/main.py
+++ b/builder/main.py
@@ -1681,6 +1681,7 @@ else:
     else:
         target_firm = env.ElfToBin(str(Path("$BUILD_DIR") / "${PROGNAME}"), target_elf)
         env.Depends(target_firm, "checkprogsize")
+        env.AddPostAction(target_firm, esp32_create_combined_bin)
 
 # Configure platform targets
 env.AddPlatformTarget(

--- a/builder/main.py
+++ b/builder/main.py
@@ -1633,10 +1633,10 @@ def esp32_create_combined_bin(source, target, env):
     for image in env.get("FLASH_EXTRA_IMAGES", []):
         offset = image[0]
         path = env.subst(image[1])
-        print(f" -  {str(offset).ljust(8)} | {path}")
+        print(f" -  {str(offset).ljust(8)} | {os.path.basename(path)}")
         cmd += [str(offset), path]
 
-    print(f" -  {app_offset.ljust(8)} | {firmware_name}")
+    print(f" -  {app_offset.ljust(8)} | {os.path.basename(firmware_name)}")
     cmd += [app_offset, firmware_name]
 
     esptool = esptool_binary_path

--- a/builder/main.py
+++ b/builder/main.py
@@ -1639,7 +1639,7 @@ def esp32_create_combined_bin(source, target, env):
     print(f" -  {app_offset.ljust(8)} | {firmware_name}")
     cmd += [app_offset, firmware_name]
 
-    esptool = uploader_path
+    esptool = esptool_binary_path
     try:
         result = subprocess.run(
             [esptool] + cmd, check=False, capture_output=True, text=True

--- a/builder/main.py
+++ b/builder/main.py
@@ -1644,7 +1644,10 @@ def esp32_create_combined_bin(source, target, env):
         result = subprocess.run(
             [esptool, *cmd], check=False, capture_output=True, text=True
         )
-        if result.returncode != 0:
+        if result.returncode == 0:
+            print("\nSuccessfully created combined binary image.")
+        else:
+            result.returncode != 0:
             print(f"\nesptool merge-bin failed (exit code {result.returncode})")
             if result.stderr:
                 print(result.stderr)

--- a/builder/main.py
+++ b/builder/main.py
@@ -1647,7 +1647,6 @@ def esp32_create_combined_bin(source, target, env):
         if result.returncode == 0:
             print("\nSuccessfully created combined binary image.")
         else:
-            result.returncode != 0:
             print(f"\nesptool merge-bin failed (exit code {result.returncode})")
             if result.stderr:
                 print(result.stderr)

--- a/builder/main.py
+++ b/builder/main.py
@@ -1644,9 +1644,7 @@ def esp32_create_combined_bin(source, target, env):
         result = subprocess.run(
             [esptool, *cmd], check=False, capture_output=True, text=True
         )
-        if result.returncode == 0:
-            print(f"\nSuccessfully created: {factory_name}")
-        else:
+        if result.returncode != 0:
             print(f"\nesptool merge-bin failed (exit code {result.returncode})")
             if result.stderr:
                 print(result.stderr)

--- a/builder/main.py
+++ b/builder/main.py
@@ -1669,7 +1669,7 @@ if "nobuild" in COMMAND_LINE_TARGETS:
 else:
     target_elf = env.BuildProgram()
     silent_action = env.Action(firmware_metrics)
-    # Hack to silence scons command output
+    # Silence scons command output
     silent_action.strfunction = lambda target, source, env: ""
     env.AddPostAction(target_elf, silent_action)
     if set(["buildfs", "uploadfs", "uploadfsota"]) & set(COMMAND_LINE_TARGETS):
@@ -1681,7 +1681,10 @@ else:
     else:
         target_firm = env.ElfToBin(str(Path("$BUILD_DIR") / "${PROGNAME}"), target_elf)
         env.Depends(target_firm, "checkprogsize")
-        env.AddPostAction(target_firm, esp32_create_combined_bin)
+        silent_action = env.Action(esp32_create_combined_bin)
+        # Silence scons command output
+        silent_action.strfunction = lambda target, source, env: ""
+        env.AddPostAction(target_firm, silent_action)
 
 # Configure platform targets
 env.AddPlatformTarget(

--- a/builder/main.py
+++ b/builder/main.py
@@ -1627,7 +1627,7 @@ def esp32_create_combined_bin(source, target, env):
         "--flash-size", flash_size,
     ]
 
-    print(f"\nCreating binary \"{os.path.basename(factory_name)}\" with:")
+    print(f"Creating binary \"{os.path.basename(factory_name)}\" with:")
     print("    Offset   | File")
 
     for image in env.get("FLASH_EXTRA_IMAGES", []):
@@ -1647,11 +1647,11 @@ def esp32_create_combined_bin(source, target, env):
         if result.returncode == 0:
             print("Successfully created combined binary image.")
         else:
-            print(f"\nesptool merge-bin failed (exit code {result.returncode})")
+            print(f"esptool merge-bin failed (exit code {result.returncode})")
             if result.stderr:
                 print(result.stderr)
     except Exception as e:
-        print(f"\nError creating factory binary: {e}")
+        print(f"Error creating factory binary: {e}")
 
 
 #

--- a/builder/main.py
+++ b/builder/main.py
@@ -1595,6 +1595,65 @@ def download_fs_action(target, source, env):
         return 1
 
 
+def esp32_create_combined_bin(source, target, env):
+    """
+    Post-build action: Combine all flash images into a single factory binary.
+    Uses esptool merge-bin to create a firmware.factory.bin that can be
+    flashed at offset 0.
+
+    Typical layout of the generated file:
+       Offset | File
+    -  0x0000 | bootloader.bin
+    -  0x8000 | partitions.bin
+    -  0xe000 | boot_app0.bin
+    - 0x10000 | firmware.bin
+    """
+    firmware_name = env.subst("$BUILD_DIR/${PROGNAME}.bin")
+    if not isfile(firmware_name):
+        return
+
+    factory_name = env.subst("$BUILD_DIR/${PROGNAME}.factory.bin")
+    flash_size = board.get("upload.flash_size", "4MB")
+    flash_mode = _get_board_flash_mode(env)
+    flash_freq = _get_board_f_image(env)
+    app_offset = env.subst("$ESP32_APP_OFFSET") or "0x10000"
+
+    cmd = [
+        "--chip", mcu,
+        "merge-bin",
+        "-o", factory_name,
+        "--flash-mode", flash_mode,
+        "--flash-freq", flash_freq,
+        "--flash-size", flash_size,
+    ]
+
+    print("\nCreating combined factory binary...")
+    print("    Offset   | File")
+
+    for image in env.get("FLASH_EXTRA_IMAGES", []):
+        offset = image[0]
+        path = env.subst(image[1])
+        print(f" -  {str(offset).ljust(8)} | {path}")
+        cmd += [str(offset), path]
+
+    print(f" -  {app_offset.ljust(8)} | {firmware_name}")
+    cmd += [app_offset, firmware_name]
+
+    esptool = uploader_path
+    try:
+        result = subprocess.run(
+            [esptool] + cmd, check=False, capture_output=True, text=True
+        )
+        if result.returncode == 0:
+            print(f"\nSuccessfully created: {factory_name}")
+        else:
+            print(f"\nesptool merge-bin failed (exit code {result.returncode})")
+            if result.stderr:
+                print(result.stderr)
+    except Exception as e:
+        print(f"\nError creating factory binary: {e}")
+
+
 #
 # Target: Build executable and linkable firmware or FS image
 #
@@ -1841,6 +1900,23 @@ env.AddPlatformTarget(
         env.VerboseAction(download_fs_action, "Downloading and extracting filesystem")
     ],
     "Download and extract filesystem from device",
+)
+
+# Target: Upload combined factory binary at offset 0
+env.AddPlatformTarget(
+    "upload_factory",
+    target_firm,
+    [
+        env.VerboseAction(esp32_create_combined_bin, "Creating combined factory binary..."),
+        env.VerboseAction(BeforeUpload, "Looking for upload port..."),
+        env.VerboseAction(
+            '$UPLOADER --chip %s --port "$UPLOAD_PORT" --baud $UPLOAD_SPEED'
+            ' write-flash 0x0 "$BUILD_DIR/${PROGNAME}.factory.bin"'
+            % mcu,
+            "Uploading factory binary $BUILD_DIR/${PROGNAME}.factory.bin",
+        ),
+    ],
+    "Upload Factory Image",
 )
 
 # Target: Erase Flash and Upload


### PR DESCRIPTION
## Description:

* **New Features**
  * Automated creation of a combined factory binary for ESP32 devices to streamline firmware deployment; produced automatically as part of the final build.

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic combined factory binary generation during builds, assembling bootloader, partitions, boot data, firmware and optional extra images while respecting flash settings and app offset.
  * Build now emits a tabulated offsets-to-files mapping and produces the combined factory binary as a post-build artifact.
  * Quieter build output with clearer build messages and improved error handling for the combined-binary step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->