### PR TITLE
feature: Install espressif Gdb Python debug module

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -68,6 +68,9 @@ spec.loader.exec_module(spiffsgen)
 SpiffsFS = spiffsgen.SpiffsFS
 SpiffsBuildConfig = spiffsgen.SpiffsBuildConfig
 
+# Import GDB_TOOL_PACKAGES from penv_setup (already loaded into sys.modules by platform.py)
+from penv_setup import GDB_TOOL_PACKAGES
+
 # Load board configuration and determine MCU architecture
 board = env.BoardConfig()
 board_id = env.subst("$BOARD")
@@ -839,9 +842,11 @@ env.Replace(
     CXX="%s-elf-g++" % toolchain_arch,
     GDB=join(
         platform.get_package_dir(
-            "tool-riscv32-esp-elf-gdb"
+            # risc-v GDB
+            GDB_TOOL_PACKAGES[1]
             if not is_xtensa
-            else "tool-xtensa-esp-elf-gdb"
+            # xtensa GDB
+            else GDB_TOOL_PACKAGES[0]
         )
         or "",
         "bin",

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -677,7 +677,7 @@ def install_freertos_gdb(platform, uv_executable, penv_executable, uv_cache_dir=
         penv_executable (str): Path to penv Python executable
         uv_cache_dir: Optional path to uv cache directory
     """
-    if not has_network::
+    if not has_network:
         return
         
     gdb_tool_packages = [

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -515,13 +515,11 @@ def _setup_python_environment_core(env, platform, platformio_dir, should_install
     uv_executable = get_executable_path(penv_dir, "uv")
 
     # Install required Python dependencies for ESP32 platform
-    if has_internet_connection() or github_actions:
+    has_network = has_internet_connection() or github_actions
+    if has_network:
         if not install_python_deps(penv_python, used_uv_executable, uv_cache_dir):
             sys.stderr.write("Error: Failed to install Python dependencies into penv\n")
             sys.exit(1)
-
-        # Install freertos-gdb into GDB tool packages
-        install_freertos_gdb(platform, uv_executable, penv_python, uv_cache_dir)
     else:
         print("Warning: No internet connection detected, Python dependency check will be skipped.")
 
@@ -679,6 +677,9 @@ def install_freertos_gdb(platform, uv_executable, penv_executable, uv_cache_dir=
         penv_executable (str): Path to penv Python executable
         uv_cache_dir: Optional path to uv cache directory
     """
+    if not has_network::
+        return
+        
     gdb_tool_packages = [
         "tool-xtensa-esp-elf-gdb",
         "tool-riscv32-esp-elf-gdb",

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -36,6 +36,7 @@ if sys.version_info < (3, 10):
     sys.exit(1)
 
 github_actions = bool(os.getenv("GITHUB_ACTIONS"))
+has_network = False  # Will be set during penv setup
 
 PLATFORMIO_URL_VERSION_RE = re.compile(
     r'/v?(\d+\.\d+\.\d+(?:[.-](?:alpha|beta|rc|dev|post|pre)\d*)?(?:\.\d+)?)(?:\.(?:zip|tar\.gz|tar\.bz2))?$',
@@ -515,6 +516,7 @@ def _setup_python_environment_core(env, platform, platformio_dir, should_install
     uv_executable = get_executable_path(penv_dir, "uv")
 
     # Install required Python dependencies for ESP32 platform
+    global has_network
     has_network = has_internet_connection() or github_actions
     if has_network:
         if not install_python_deps(penv_python, used_uv_executable, uv_cache_dir):

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -36,7 +36,6 @@ if sys.version_info < (3, 10):
     sys.exit(1)
 
 github_actions = bool(os.getenv("GITHUB_ACTIONS"))
-has_network = has_internet_connection() or github_actions
 
 PLATFORMIO_URL_VERSION_RE = re.compile(
     r'/v?(\d+\.\d+\.\d+(?:[.-](?:alpha|beta|rc|dev|post|pre)\d*)?(?:\.\d+)?)(?:\.(?:zip|tar\.gz|tar\.bz2))?$',
@@ -108,6 +107,9 @@ def has_internet_connection(timeout=5):
     # Direct DNS:53 connection is abolished due to many false positives on enterprise networks
     # (add it at the end if necessary)
     return False
+
+
+has_network = has_internet_connection() or github_actions
 
 
 def get_executable_path(penv_dir, executable_name):
@@ -699,10 +701,11 @@ def install_freertos_gdb(platform, uv_executable, penv_executable, uv_cache_dir=
             continue
         try:
             subprocess.check_call([
-            uv_executable, "pip", "install", "--quiet",
-                 f"--python={penv_executable}",
-                 "--target", target_dir,
-                "freertos-gdb"],
+                uv_executable, "pip", "install", "--quiet",
+                f"--python={penv_executable}",
+                "--target", str(target_dir),
+                "freertos-gdb"
+            ],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.STDOUT,
                 timeout=60,

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -80,7 +80,7 @@ def has_internet_connection(timeout=5):
     # Check if offline mode is forced via environment variable
     if os.getenv("PLATFORMIO_OFFLINE", "").strip().lower() in ("1", "true", "yes"):
         return False
-    
+
     # 1) Test TCP connectivity to the proxy endpoint.
     proxy = os.getenv("HTTPS_PROXY") or os.getenv("https_proxy") or os.getenv("HTTP_PROXY") or os.getenv("http_proxy")
     if proxy:
@@ -519,6 +519,9 @@ def _setup_python_environment_core(env, platform, platformio_dir, should_install
         if not install_python_deps(penv_python, used_uv_executable, uv_cache_dir):
             sys.stderr.write("Error: Failed to install Python dependencies into penv\n")
             sys.exit(1)
+
+        # Install freertos-gdb into GDB tool packages
+        install_freertos_gdb(platform, uv_executable, penv_python, uv_cache_dir)
     else:
         print("Warning: No internet connection detected, Python dependency check will be skipped.")
 
@@ -661,6 +664,52 @@ def _install_esptool_from_tl_install(platform, python_exe, uv_executable, uv_cac
     except subprocess.CalledProcessError as e:
         print(f"Warning: Failed to install esptool from {esptool_repo_path} (exit {e.returncode})")
         # Don't exit - esptool installation is not critical for penv setup
+
+
+def install_freertos_gdb(platform, uv_executable, penv_executable, uv_cache_dir=None):
+    """
+    Install freertos-gdb into each GDB tool's embedded Python site (share/gdb/python/).
+
+    Iterates over all GDB tool packages known to the platform and installs
+    the freertos-gdb PyPI package via uv if not already present.
+
+    Args:
+        platform: PlatformIO platform object
+        uv_executable (str): Path to uv executable
+        penv_executable (str): Path to penv Python executable
+        uv_cache_dir: Optional path to uv cache directory
+    """
+    gdb_tool_packages = [
+        "tool-xtensa-esp-elf-gdb",
+        "tool-riscv32-esp-elf-gdb",
+    ]
+
+    uv_env = None
+    if uv_cache_dir:
+        uv_env = dict(os.environ)
+        uv_env["UV_CACHE_DIR"] = str(uv_cache_dir)
+
+    for tool_pkg in gdb_tool_packages:
+        pkg_dir = platform.get_package_dir(tool_pkg)
+        if not pkg_dir or not Path(pkg_dir).is_dir():
+            continue
+        target_dir = Path(pkg_dir, "share", "gdb", "python")
+        if Path(target_dir, "freertos_gdb").is_dir():
+            continue
+        try:
+            subprocess.check_call([
+            uv_executable, "pip", "install", "--quiet",
+                 f"--python={penv_executable}",
+                 "--target", target_dir,
+                "freertos-gdb"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT,
+                timeout=60,
+                env=uv_env,
+            )
+            print(f"Installed freertos-gdb into {target_dir}")
+        except Exception as exc:
+            print(f"Warning: Failed to install freertos-gdb into {target_dir}: {exc}")
 
 
 def _setup_certifi_env(env, python_exe):

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -36,7 +36,7 @@ if sys.version_info < (3, 10):
     sys.exit(1)
 
 github_actions = bool(os.getenv("GITHUB_ACTIONS"))
-has_network = False  # Will be set during penv setup
+has_network = has_internet_connection() or github_actions
 
 PLATFORMIO_URL_VERSION_RE = re.compile(
     r'/v?(\d+\.\d+\.\d+(?:[.-](?:alpha|beta|rc|dev|post|pre)\d*)?(?:\.\d+)?)(?:\.(?:zip|tar\.gz|tar\.bz2))?$',
@@ -516,8 +516,6 @@ def _setup_python_environment_core(env, platform, platformio_dir, should_install
     uv_executable = get_executable_path(penv_dir, "uv")
 
     # Install required Python dependencies for ESP32 platform
-    global has_network
-    has_network = has_internet_connection() or github_actions
     if has_network:
         if not install_python_deps(penv_python, used_uv_executable, uv_cache_dir):
             sys.stderr.write("Error: Failed to install Python dependencies into penv\n")

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -26,6 +26,11 @@ from urllib.parse import urlparse
 from platformio.package.version import pepver_to_semver
 from platformio.compat import IS_WINDOWS
 
+GDB_TOOL_PACKAGES = [
+    "tool-xtensa-esp-elf-gdb",
+    "tool-riscv32-esp-elf-gdb",
+]
+
 # Check Python version requirement
 if sys.version_info < (3, 10):
     sys.stderr.write(
@@ -682,17 +687,12 @@ def install_freertos_gdb(platform, uv_executable, penv_executable, uv_cache_dir=
     if not has_network:
         return
         
-    gdb_tool_packages = [
-        "tool-xtensa-esp-elf-gdb",
-        "tool-riscv32-esp-elf-gdb",
-    ]
-
     uv_env = None
     if uv_cache_dir:
         uv_env = dict(os.environ)
         uv_env["UV_CACHE_DIR"] = str(uv_cache_dir)
 
-    for tool_pkg in gdb_tool_packages:
+    for tool_pkg in GDB_TOOL_PACKAGES:
         pkg_dir = platform.get_package_dir(tool_pkg)
         if not pkg_dir or not Path(pkg_dir).is_dir():
             continue

--- a/platform.py
+++ b/platform.py
@@ -63,12 +63,14 @@ from platformio.package.manager.tool import ToolPackageManager
 penv_setup_path = Path(__file__).parent / "builder" / "penv_setup.py"
 spec = importlib.util.spec_from_file_location("penv_setup", str(penv_setup_path))
 penv_setup_module = importlib.util.module_from_spec(spec)
+sys.modules["penv_setup"] = penv_setup_module
 spec.loader.exec_module(penv_setup_module)
 
 setup_penv_minimal = penv_setup_module.setup_penv_minimal
 get_executable_path = penv_setup_module.get_executable_path
 has_internet_connection = penv_setup_module.has_internet_connection
 install_freertos_gdb = penv_setup_module.install_freertos_gdb
+GDB_TOOL_PACKAGES = penv_setup_module.GDB_TOOL_PACKAGES
 
 
 # Constants
@@ -86,13 +88,13 @@ ESP_BUILTIN_DEBUG_MCUS = frozenset([
 MCU_TOOLCHAIN_CONFIG = {
     "xtensa": {
         "mcus": frozenset(["esp32", "esp32s2", "esp32s3"]),
-        "toolchains": ["toolchain-xtensa-esp-elf", "tool-xtensa-esp-elf-gdb"]
+        "toolchains": ["toolchain-xtensa-esp-elf", GDB_TOOL_PACKAGES[0]]
     },
     "riscv": {
         "mcus": frozenset([
             "esp32c2", "esp32c3", "esp32c5", "esp32c6", "esp32c61", "esp32h2", "esp32p4"
         ]),
-        "toolchains": ["toolchain-riscv32-esp", "tool-riscv32-esp-elf-gdb"]
+        "toolchains": ["toolchain-riscv32-esp", GDB_TOOL_PACKAGES[1]]
     }
 }
 

--- a/platform.py
+++ b/platform.py
@@ -787,8 +787,7 @@ class Espressif32Platform(PlatformBase):
             self._configure_mcu_toolchains(mcu, variables, targets)
             
             # Install freertos-gdb after MCU toolchains are installed
-            install_freertos_gdb(self, get_executable_path(Path(penv_python).parent, "uv"), 
-                               penv_python, str(Path(core_dir) / ".cache" / "uv"))
+            install_freertos_gdb(self, get_executable_path(str(Path(core_dir) / "penv"), "uv"), penv_python, str(Path(core_dir) / ".cache" / "uv"))
 
             if "espidf" in frameworks:
                 self._install_common_idf_packages()

--- a/platform.py
+++ b/platform.py
@@ -963,12 +963,11 @@ class Espressif32Platform(PlatformBase):
             list[str]: GDB command strings that attempt to import the `freertos_gdb` Python
             extension and print a warning if it is not available.
         """
+        # Use single-line try/except to survive cleanup_cmds stripping indentation
         return [
             "python",
-            "try:",
-            "    import freertos_gdb",
-            "except ModuleNotFoundError:",
-            "    print('warning: python extension \"freertos_gdb\" not found.')",
+            "try: import freertos_gdb",
+            "except ModuleNotFoundError: print('warning: python extension \"freertos_gdb\" not found.')",
             "end",
         ]
 

--- a/platform.py
+++ b/platform.py
@@ -68,6 +68,7 @@ spec.loader.exec_module(penv_setup_module)
 setup_penv_minimal = penv_setup_module.setup_penv_minimal
 get_executable_path = penv_setup_module.get_executable_path
 has_internet_connection = penv_setup_module.has_internet_connection
+install_freertos_gdb = penv_setup_module.install_freertos_gdb
 
 
 # Constants
@@ -784,6 +785,10 @@ class Espressif32Platform(PlatformBase):
             self._configure_arduino_framework(frameworks, mcu)
             self._configure_espidf_framework(frameworks, variables, board_config, mcu)
             self._configure_mcu_toolchains(mcu, variables, targets)
+            
+            # Install freertos-gdb after MCU toolchains are installed
+            install_freertos_gdb(self, get_executable_path(Path(penv_python).parent, "uv"), 
+                               penv_python, str(Path(core_dir) / ".cache" / "uv"))
 
             if "espidf" in frameworks:
                 self._install_common_idf_packages()


### PR DESCRIPTION


## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automatic installation of the freertos-gdb extension into embedded Python environments for installed GDB tools to improve debugging.
  * Installation respects network availability and will skip gracefully when offline.
  * GDB command snippets simplified for more reliable extension loading.
  * GDB tool selection made dynamic to support multiple tool variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->