### PR TITLE
Add LilyGo T-Energy-S3 board definition

### DIFF
--- a/boards/lilygo-t-energy-s3.json
+++ b/boards/lilygo-t-energy-s3.json
@@ -1,0 +1,50 @@
+{
+  "build": {
+    "arduino": {
+      "memory_type": "qio_opi",
+      "partitions": "default_16MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_LILYGO_T_ENERGY_S3",
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DARDUINO_USB_MODE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "psram_type": "opi",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "LilyGo T-Energy-S3",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.lilygo.cc/products/t-energy-s3",
+  "vendor": "LilyGo"
+}


### PR DESCRIPTION
## Description:

Add board definition for the LilyGo T-Energy-S3, an ESP32-S3 board with:
- 16MB QIO flash
- 8MB OPI PSRAM
- USB-C (CDC on boot)
- 18650 battery holder with onboard power management

Product page: https://www.lilygo.cc/products/t-energy-s3

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)