### PR TITLE
Fix: include file contents in custom_sdkconfig hash computation

### DIFF
--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -75,6 +75,8 @@ class PathCache:
     @property
     def sdk_dir(self):
         if self._sdk_dir is None:
+            if self.framework_lib_dir is None:
+                return None
             self._sdk_dir = fs.to_unix_path(
                 str(Path(self.framework_lib_dir) / self.chip_variant / "include")
             )
@@ -277,6 +279,23 @@ if config.has_option(current_env_section, "custom_component_remove"):
 # Custom SDKConfig check
 if config.has_option(current_env_section, "custom_sdkconfig"):
     entry_custom_sdkconfig = env.GetProjectOption("custom_sdkconfig")
+    # When custom_sdkconfig references a file, include its contents in the
+    # value used for hash computation. Otherwise, editing the file doesn't
+    # change the hash and stale libs are silently reused.
+    # Combine file content with inline options (both are applied by the build).
+    for line in entry_custom_sdkconfig.splitlines():
+        line = line.strip()
+        if line.startswith("file://"):
+            file_ref = line[7:]
+            file_path = file_ref if isabs(file_ref) else join(project_dir, file_ref)
+            if exists(file_path):
+                try:
+                    with open(file_path, 'r') as f:
+                        file_content = f.read()
+                    entry_custom_sdkconfig = file_content + "\n" + entry_custom_sdkconfig
+                except IOError:
+                    pass
+            break
     flag_custom_sdkconfig = True
 
 if board_sdkconfig:

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -779,11 +779,18 @@ def HandleArduinoIDFsettings(env):
     # Convert to list for processing
     idf_config_list = [line for line in idf_config_flags.splitlines() if line.strip()]
     
-    # Write final configuration file with checksum
+    # Write final configuration file with checksum.
+    # Include resolved file content (not just the raw "file://..." reference)
+    # so that editing the referenced file changes the hash and triggers
+    # recompilation. Combine file content + inline options to match what
+    # build_idf_config_flags() produces.
     custom_sdk_config_flags = ""
     if config.has_option("env:" + env["PIOENV"], "custom_sdkconfig"):
-        custom_sdk_config_flags = env.GetProjectOption("custom_sdkconfig").rstrip("\n") + "\n"
-    
+        raw = env.GetProjectOption("custom_sdkconfig")
+        resolved = load_custom_sdkconfig_file()
+        # Combine resolved file content with raw inline options (both are applied)
+        custom_sdk_config_flags = ((resolved + "\n") if resolved else "") + raw.rstrip("\n") + "\n"
+
     write_sdkconfig_file(idf_config_list, custom_sdk_config_flags)
 
 


### PR DESCRIPTION
  ## Problem

When `custom_sdkconfig` uses a `file://` reference:
```ini
custom_sdkconfig = file://sdkconfig.custom
```
the hash used to detect configuration changes is computed from the literal text "file://sdkconfig.custom" rather than the file's actual contents. Editing the referenced file doesn't  hange the hash, so matching_custom_sdkconfig() returns True and stale recompiled libs are silently reused — even if the file now disables a major feature like Bluetooth.

This is the only way to pass Kconfig disable syntax (# CONFIG_BT_ENABLED is not set) since # lines in platformio.ini  are stripped by the INI parser.

## Fix

Resolve file:// references before hash computation in both arduino.py (where the hash is checked via matching_custom_sdkconfig()) and espidf.py (where it is written via write_sdkconfig_file()). Both sides now hash the resolved file contents + inline options + MCU name, so editing the file triggers lib recompilation via the existing Reinstall path (which also runs safe_remove_sdkconfig_files() to clean stale per-env sdkconfigs).

Inline custom_sdkconfig values (without file://) are unaffected.

Also guards PathCache.sdk_dir against framework_lib_dir being None (crashes with TypeError on Python 3.13 when framework packages are not yet installed). I'll admit I'm not sure why this kept happening in testing.

## Repro

platformio.ini:
```ini
[env:test]
platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
framework = arduino
board = dfrobot_firebeetle2_esp32e
custom_sdkconfig = file://sdkconfig.custom
custom_component_remove =
    espressif/esp_insights
    espressif/esp_rainmaker
    espressif/rmaker_common
    espressif/esp_diag_data_store
    espressif/esp_diagnostics
```
sdkconfig.custom (initial):
```ini
CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM=4
```

```
  rm -rf .pio sdkconfig.*
  pio run -e test          # Build 1: compiles libs, hash=3d58653b
```

  Now edit sdkconfig.custom to add # CONFIG_BT_ENABLED is not set:
```
  pio run -e test          # Build 2: NO recompile (7s cached), hash unchanged
                           # BT still reserved (0xdb5c = 55KB) — file change silently ignored
```

With this fix, Build 2 detects the hash mismatch, triggers Reinstall + recompile, and properly disables BT (BTDM_RESERVE_DRAM drops from 0xdb5c to 0).

## Use of AI
This PR was generated with the assistance of Claude Code (claude-opus-4-6). Do let me know if it still looks completely wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Custom sdkconfig files referenced in project configuration now properly affect build cache validation, ensuring changes to these files trigger necessary rebuilds of compiled libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->