### PR TITLE
Remove unnecessary urllib3<2 pin (conflicts with modern platformio)

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2108,8 +2108,6 @@ def install_python_deps():
         return
 
     deps = {
-        # https://github.com/platformio/platformio-core/issues/4614
-        "urllib3": "<2",
         # https://github.com/platformio/platform-espressif32/issues/635
         "cryptography": "~=44.0.0",
         "pyparsing": ">=3.1.0,<4",

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -57,7 +57,6 @@ python_deps = {
     "zopfli": ">=0.2.2",
     "intelhex": ">=2.3.0",
     "rich": ">=14.0.0",
-    "urllib3": "<2",
     "cryptography": ">=45.0.3",
     "certifi": ">=2025.8.3",
     "ecdsa": ">=0.19.1",


### PR DESCRIPTION
The unconditional `urllib3<2` pin in both `penv_setup.py` and `espidf.py` conflicts with modern platformio-core which pulls in `urllib3>=2`.

This causes unnecessary reinstalls every build — platformio upgrades urllib3 to v2, then the next dependency check sees `urllib3<2` is unsatisfied and reinstalls it, which triggers another platformio check. The build still succeeds but wastes time on redundant package installs.

The original pin was for [platformio/platformio-core#4614](https://github.com/platformio/platformio-core/issues/4614) — urllib3 v2 requires OpenSSL 1.1.1+. Upstream platformio-core already handles this conditionally (only pins `urllib3<2` when OpenSSL < 1.1.1). OpenSSL 1.1.1 went EOL in September 2023 and all modern platforms (HA OS, Docker, any Linux distro from the last 3+ years) ship OpenSSL 3.x.

Tested on ESP32-P4 (IDF 5.5.3) and ESP32-C3 — no dependency conflicts, clean builds with `urllib3==2.6.3`.

Related: https://github.com/esphome/esphome/issues/15074