### PR TITLE
Run ensurepip before pip fallback (uv-created venvs lack pip)

### DIFF
--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -286,6 +286,14 @@ def install_python_deps(python_exe, external_uv_executable, uv_cache_dir=None):
 
         if not uv_in_penv_available:
             # Fallback to pip to install uv into penv
+            # uv-created venvs don't include pip, so ensure it's available first
+            try:
+                subprocess.run(
+                    [python_exe, "-m", "ensurepip", "--default-pip"],
+                    capture_output=True, timeout=60
+                )
+            except Exception:
+                pass
             try:
                 subprocess.check_call(
                     [python_exe, "-m", "pip", "install", "uv>=0.1.0", "--quiet", "--no-cache-dir"],


### PR DESCRIPTION
When the penv is created by uv, pip is not included. If the external uv fails to install uv into the penv (e.g. timeout), the pip fallback fails with `No module named pip`.

Fix by running `ensurepip` to bootstrap pip before the pip fallback. `ensurepip` is a Python stdlib module that installs pip from a bundled wheel — no network needed.

```
DEBUG: uv not found in penv, attempting install
DEBUG: python_exe=/root/.platformio/penv/bin/python
DEBUG: external_uv_executable=/usr/local/bin/uv
Warning: uv installation via external uv timed out after 300s
Error: uv installation via pip failed with exit code 1
DEBUG: stderr: /root/.platformio/penv/bin/python: No module named pip
```

Related: https://github.com/esphome/esphome/issues/15074

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved virtual environment setup process with enhanced package initialization to ensure more reliable dependency installation in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->