### PR TITLE
fix: LittleFS Filename encoding UTF-8

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -52,6 +52,8 @@ build_dir = Path(projectconfig.get("platformio", "build_dir"))
 PYTHON_EXE, esptool_binary_path = platform.setup_python_env(env)
 
 from littlefs import LittleFS
+from littlefs import lfs as _lfs
+_lfs.FILENAME_ENCODING = "utf-8"
 from fatfs import Partition, RamDisk, create_extended_partition
 from fatfs import create_esp32_wl_image
 from fatfs import calculate_esp32_wl_overhead
@@ -298,7 +300,7 @@ def _parse_partitions(env):
     next_offset = 0
     app_offset = 0x10000  # Default address for firmware
 
-    with open(partitions_csv) as fp:
+    with open(partitions_csv, encoding="utf-8") as fp:
         for line in fp.readlines():
             line = line.strip()
             if not line or line.startswith("#"):

--- a/builder/main.py
+++ b/builder/main.py
@@ -300,7 +300,7 @@ def _parse_partitions(env):
     next_offset = 0
     app_offset = 0x10000  # Default address for firmware
 
-    with open(partitions_csv, encoding="utf-8") as fp:
+    with open(partitions_csv) as fp:
         for line in fp.readlines():
             line = line.strip()
             if not line or line.startswith("#"):


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** [LittleFS build can not support Taiwan traditional](https://github.com/espressif/arduino-esp32/issues/12484)

* **Bug Fixes**
  * Improved UTF-8 encoding support for filesystem operations


## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
