### PR TITLE
Remove 'chardet' dependency for macOS ARM

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -24,7 +24,6 @@ import copy
 import importlib.util
 import json
 import os
-import platform as sys_platform
 import re
 import requests
 import shutil

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2115,9 +2115,6 @@ def install_python_deps():
         "esp-idf-kconfig": "~=2.5.0"
     }
 
-    if sys_platform.system() == "Darwin" and "arm" in sys_platform.machine().lower():
-        deps["chardet"] = ">=3.0.2,<4"
-
     python_exe_path = get_python_exe()
     installed_packages = _get_installed_uv_packages(python_exe_path)
     packages_to_install = []


### PR DESCRIPTION
Removed conditional dependency for 'chardet' on macOS ARM.

## Description:

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed redundant platform-specific dependency handling logic, streamlining the build configuration process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->