### PR TITLE
add HybridCompile sdkconfig file to hash

### DIFF
--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -277,6 +277,20 @@ if config.has_option(current_env_section, "custom_component_remove"):
 # Custom SDKConfig check
 if config.has_option(current_env_section, "custom_sdkconfig"):
     entry_custom_sdkconfig = env.GetProjectOption("custom_sdkconfig")
+    # When custom_sdkconfig references a file, include its mtime in the
+    # value used for hash computation. A changed mtime means a new hash
+    # and triggers the existing Reinstall path.
+    for line in entry_custom_sdkconfig.splitlines():
+        line = line.strip()
+        if line.startswith("file://"):
+            file_ref = line[7:]
+            file_path = file_ref if isabs(file_ref) else join(project_dir, file_ref)
+            try:
+                mtime = str(os.path.getmtime(file_path))
+                entry_custom_sdkconfig = mtime + "\n" + entry_custom_sdkconfig
+            except OSError:
+                pass
+            break
     flag_custom_sdkconfig = True
 
 if board_sdkconfig:

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -75,6 +75,8 @@ class PathCache:
     @property
     def sdk_dir(self):
         if self._sdk_dir is None:
+            if not self.framework_lib_dir:
+                return None
             self._sdk_dir = fs.to_unix_path(
                 str(Path(self.framework_lib_dir) / self.chip_variant / "include")
             )

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -779,9 +779,23 @@ def HandleArduinoIDFsettings(env):
     idf_config_list = [line for line in idf_config_flags.splitlines() if line.strip()]
     
     # Write final configuration file with checksum
+    # Include the mtime of any referenced file (not just the raw "file://..."
+    # string) so that editing the file changes the hash and triggers recompilation. 
     custom_sdk_config_flags = ""
     if config.has_option("env:" + env["PIOENV"], "custom_sdkconfig"):
-        custom_sdk_config_flags = env.GetProjectOption("custom_sdkconfig").rstrip("\n") + "\n"
+        raw = env.GetProjectOption("custom_sdkconfig")
+        file_mtime = ""
+        for entry in raw.splitlines():
+            entry = entry.strip()
+            if entry.startswith("file://"):
+                file_ref = entry[7:]
+                file_path = file_ref if os.path.isabs(file_ref) else str(Path(PROJECT_DIR) / file_ref)
+                try:
+                    file_mtime = str(os.path.getmtime(file_path))
+                except OSError:
+                    pass
+                break
+        custom_sdk_config_flags = (file_mtime + "\n" if file_mtime else "") + raw.rstrip("\n") + "\n"
     
     write_sdkconfig_file(idf_config_list, custom_sdk_config_flags)
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #441

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection for custom SDK configuration files that reference local external files: referenced paths are now resolved relative to the project when needed, modification times are considered, and missing files are ignored without causing failures.
  * Prevented constructing SDK include paths when framework library directories are unavailable, avoiding spurious rebuilds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->