### PR TITLE
refactor: delete explicit Windows path length issue code, just verify

### DIFF
--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -482,21 +482,21 @@ if ("arduino" in pioframework and "espidf" not in pioframework and
     env.AddPostAction("checkprogsize", silent_action)
 
     if IS_WINDOWS and not IS_INTEGRATION_DUMP:
-        from SCons.Platform import TempFileMunge
-
         check_and_warn_long_path_support()
 
-        # TempFileMunge for *COM-variables - set before SCons script
-        # env.Append in MCU-Script does not overwrite the wrapper
-        env["TEMPFILE"]       = TempFileMunge
-        env["TEMPFILEPREFIX"] = "@"
-        env["TEMPFILESUFFIX"] = ".rsp"
-        env["MAXLINELENGTH"]  = 4096  # increase the conservative default value of 2048
+        # Check that piomaxlen.py has enabled fix for long command-lines.
 
-        for _var in ["CCCOM", "CXXCOM", "ASCOM", "ASPPCOM", "LINKCOM"]:
-            if _var in env and "TEMPFILE" not in str(env[_var]):
-                env[_var] = "${TEMPFILE('%s')}" % env[_var]
+        if env["TEMPFILE"] is None:
+            sys.stderr.write(f"Error: TEMPFILE should be set\n")
+            env.Exit(1)
 
+        if env["MAXLINELENGTH"] < 4096:
+            sys.stderr.write(f"Error: MAXLINELENGTH should be >= 4096 (was: {env['MAXLINELENGTH']})\n")
+            env.Exit(1)
+
+        if "${TEMPFILE(" not in env["CCCOM"]:
+            sys.stderr.write(f"Error: CCCOM must use TEMPFILE (was: {env['CCCOM']})\n")
+            env.Exit(1)
 
     build_script_path = str(Path(FRAMEWORK_DIR) / "tools" / "pioarduino-build.py")
     SConscript(build_script_path)


### PR DESCRIPTION
that piomaxlen.py ran

Discussed in
https://github.com/pioarduino/platform-espressif32/issues/440

## Description:

**Related issue (if applicable):** fixes #440

## Checklist:
  - [X] The pull request is done against the latest develop branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [X] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)
