### PR TITLE
allow Python 3.14 for Windows

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/platform.py
+++ b/platform.py
@@ -17,16 +17,12 @@ import sys
 from platformio.compat import IS_WINDOWS
 
 pyver = sys.version_info
-if IS_WINDOWS:
-    allowed = (3, 10) <= pyver < (3, 14)
-    supported = "3.10, 3.11, 3.12, 3.13"
-else:
-    allowed = (3, 10) <= pyver < (3, 15)
-    supported = "3.10, 3.11, 3.12, 3.13, 3.14"
+allowed = (3, 10) <= pyver < (3, 15)
+supported = "3.10, 3.11, 3.12, 3.13, 3.14"
+
 if not allowed:
     print(f"ERROR: Python version must be {supported}.", file=sys.stderr)
     print(f"Current Python version: {pyver.major}.{pyver.minor}.{pyver.micro}", file=sys.stderr)
-    print(f"Supported versions: {supported}", file=sys.stderr)
     raise SystemExit(1)
 
 # LZMA support check


### PR DESCRIPTION


## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated continuous integration workflow to test with Python 3.14.

* **Refactor**
  * Consolidated Python version validation logic across all platforms.
  * Standardized supported Python versions to 3.10–3.14 across all operating systems.
  * Improved error messaging for version requirement failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->