### PR TITLE
Fix in espidf.py to handle spaces in linker fragment paths from Ninja build files

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1320,9 +1320,12 @@ def extract_linker_script_fragments(
         for line in fp.readlines():
             if "sections.ld: CUSTOM_COMMAND" not in line:
                 continue
-            for fragment_match in re.finditer(r"(\S+\.lf\b)+", line):
+            # Ninja escapes special characters with '$': spaces become '$ ',
+            # colons become '$:'. The regex must treat '$'+char as part of
+            # the path so that paths containing spaces are not split.
+            for fragment_match in re.finditer(r"(?:\$.|[^\s])+\.lf\b", line):
                 result.append(_normalize_fragment_path(
-                    BUILD_DIR, fragment_match.group(0).replace("$:", ":")
+                    BUILD_DIR, fragment_match.group(0).replace("$:", ":").replace("$ ", " ")
                 ))
 
             break


### PR DESCRIPTION
## Description:

`extract_linker_script_fragments` in espidf.py uses `re.finditer(r"(\S+\.lf\b)+", line)` to extract linker fragment paths from the Ninja build file. Ninja escapes special characters with `$`, so spaces become `$ ` and colons become `$:`. Because \S+ splits on whitespace, any .lf path containing spaces gets truncated. The truncated tail is then joined with BUILD_DIR by `_normalize_fragment_path`, producing a mangled path that doesn't exist.

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of linker fragment paths containing spaces and special characters in the build system, ensuring builds complete correctly when paths include these characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->