### PR TITLE
feat: add ESP-Prog 2 debug tool support

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -842,6 +842,7 @@ class Espressif32Platform(PlatformBase):
         supported_debug_tools = [
             "cmsis-dap",
             "esp-prog",
+            "esp-prog-2",
             "esp-bridge",
             "iot-bus-jtag",
             "jlink",
@@ -1109,7 +1110,7 @@ class Espressif32Platform(PlatformBase):
             if board.id == "esp32-s2-kaluga-1":
                 return "ftdi/esp32s2_kaluga_v1"
             return "ftdi/esp_ftdi"
-        if link == "esp-bridge":
+        if link in ("esp-prog-2", "esp-bridge"):
             return "esp_usb_bridge"
         if link == "esp-builtin":
             return "esp_usb_jtag"


### PR DESCRIPTION
## Summary

Add support for the **ESP-Prog 2** debug probe as a new debug tool.

ESP-Prog 2 is the successor to the original ESP-Prog. It replaces the FTDI chip with Espressif's own USB JTAG bridge (VID `0x303a`, PID `0x1002`), but provides the same JTAG debugging functionality.

## Changes

- Add `esp-prog-2` to the list of supported debug tools (available for all boards)
- Map `esp-prog-2` to the `esp_usb_bridge` OpenOCD interface config, which is already shipped with `openocd-esp32` ([`tcl/interface/esp_usb_bridge.cfg`](https://github.com/espressif/openocd-esp32/blob/master/tcl/interface/esp_usb_bridge.cfg))

## Usage

```ini
[env:myboard]
platform = espressif32
board = esp32dev
debug_tool = esp-prog-2
```

## Notes

- The `esp_usb_bridge.cfg` interface config is available since openocd-esp32 v0.12.0
- The udev rule for ESP-Prog 2 (`303a:1002`) needs to be added in platformio-core

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `esp-prog-2` debug tool alongside existing debuggers
  * `esp-prog-2` now uses the same OpenOCD interface configuration as `esp-bridge`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->