### PR TITLE
Skip FileDownloader monkey-patch when native retry support exists

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -146,6 +146,11 @@ def patch_file_downloader():
     from platformio.package.download import FileDownloader
     from platformio.package.exception import PackageException
 
+    # Skip if FileDownloader already has native retry support (platformio-core with RETRY)
+    if hasattr(FileDownloader, "RETRY"):
+        logger.debug("FileDownloader has native retry support, skipping monkey-patch")
+        return
+
     if getattr(FileDownloader.__init__, "_patched", False):
         return
 


### PR DESCRIPTION
## Summary

Detects if `platformio-core`'s `FileDownloader` already has native retry support by checking for the `RETRY` class attribute. When present, the monkey-patch from #463 is skipped to avoid:

- **Double retries**: native urllib3.Retry (5×) + monkey-patch (5×) = up to 25 attempts with ~62s+ total wait
- **Exception mismatch**: native code raises `IOError` on network failures, not `PackageException`, so the monkey-patch's `except PackageException` wouldn't catch them anyway
- **Redundant cleanup**: closing already-managed session/response objects

## How it works

```python
if hasattr(FileDownloader, 'RETRY'):
    logger.debug('FileDownloader has native retry support, skipping monkey-patch')
    return
```

- **Unmodified platformio-core**: `RETRY` attribute absent → monkey-patch applies as before
- **Enhanced platformio-core**: `RETRY` attribute present → monkey-patch skipped, native retry handles everything

## Checklist
- [x] The pull request is done against the latest develop branch
- [x] Only relevant files were touched
- [x] Only one feature/fix was added per PR
- [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal file download retry mechanism to detect and utilize native platform support when available, streamlining the download handling process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->