### PR TITLE
fix: remove Tcl braces from program_esp commands in OpenOCD upload

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -1851,7 +1851,7 @@ elif upload_protocol in debug_tools:
             "-c",
             "adapter speed %s" % env.GetProjectOption("debug_speed", "5000"),
             "-c",
-            "program_esp {{$SOURCE}} %s verify"
+            "program_esp {$SOURCE} %s verify"
             % (
                 "$FS_START"
                 if "uploadfs" in COMMAND_LINE_TARGETS
@@ -1864,7 +1864,7 @@ elif upload_protocol in debug_tools:
             openocd_args.extend(
                 [
                     "-c",
-                    "program_esp {{%s}} %s verify"
+                    "program_esp {%s} %s verify"
                     % (_to_unix_slashes(image[1]), image[0]),
                 ]
             )


### PR DESCRIPTION
## Problem

When using `upload_protocol = esp-builtin` (or any OpenOCD-based debug tool upload), flashing fails with:

```
Error: couldn't open {.pio/build/esp32-s3-devkitc1-n16r8/firmware.bin}
```

## Root Cause

Lines 1854 and 1867 in `builder/main.py` wrap file paths in Tcl braces (`{{...}}`):

```python
"program_esp {{\}} %s verify"
"program_esp {{%s}} %s verify"
```

The OpenOCD script `esp_common.cfg` (line 453) already wraps the filename in double quotes for space handling. The combination causes the braces to become literal characters in the filename.

## Fix

Remove the Tcl braces, since `esp_common.cfg` already handles quoting.

Fixes #466