### PR TITLE
feat: auto-install tool-clangd-esp when IDE uses clangd IntelliSense

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -797,6 +797,19 @@ class Espressif32Platform(PlatformBase):
             if any(tool in package for tool in check_tools):
                 self.install_tool(package)
 
+    def _configure_clangd_tool(self) -> None:
+        """Install Espressif's clangd when the IDE has clangd IntelliSense enabled.
+
+        The pioarduino IDE extension exports PLATFORMIO_IDE_INTELLISENSE_ENGINE
+        so the platform can automatically install the matching tool package.
+        Espressif's clangd has native Xtensa and ESP RISC-V support that the
+        upstream clangd lacks.
+        """
+        engine = os.environ.get("PLATFORMIO_IDE_INTELLISENSE_ENGINE", "")
+        if engine == "clangd" and "tool-clangd-esp" in self.packages:
+            logger.info("clangd IntelliSense engine detected, installing tool-clangd-esp")
+            self.install_tool("tool-clangd-esp")
+
     def _handle_dfuutil_tool(self, variables: Dict) -> None:
         """Install dfuutil tool for Arduino Nano ESP32 board."""
         board_config = self.board_config(variables.get("board"))
@@ -851,6 +864,7 @@ class Espressif32Platform(PlatformBase):
 
             self._configure_rom_elfs_for_exception_decoder(variables)
             self._configure_check_tools(variables)
+            self._configure_clangd_tool()
             self._handle_dfuutil_tool(variables)
 
             logger.info("Package configuration completed successfully")


### PR DESCRIPTION
## Summary

The pioarduino IDE extension now exports `PLATFORMIO_IDE_INTELLISENSE_ENGINE` as an environment variable (via `patchOSEnviron()`). When its value is `clangd`, the platform automatically installs the `tool-clangd-esp` package during `configure_default_packages()`.

## How it works

```
IDE Extension (patchOSEnviron)
  │
  └─ sets PLATFORMIO_IDE_INTELLISENSE_ENGINE=clangd
       │
       └─ platform.py (configure_default_packages)
            │
            └─ _configure_clangd_tool()
                 │
                 └─ reads env var → installs tool-clangd-esp
```

The IDE extension then detects the installed binary at `packages/tool-clangd-esp/esp-clangd/bin/clangd` and sets `clangd.path` accordingly.

## Why

Espressif's clangd has native Xtensa and ESP RISC-V ISA extension support (`xespv`, `xesploop`, `xespdsp`, etc.) that the upstream clangd lacks. This eliminates unknown-flag errors and greatly improves IntelliSense for all ESP32 targets.

## Changes

- **`platform.py`**: Added `_configure_clangd_tool()` method and call in `configure_default_packages()`
- **Companion IDE change**: `src/main.js` in pioarduino-vscode-ide sets the env var