### PR TITLE
feature: Use espressif modified clangd tool

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -135,6 +135,13 @@
       "package-version": "2.20.1",
       "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/cppcheck-v2.20.1.zip"
     },
+    "tool-clangd-esp": {
+      "type": "tool",
+      "optional": true,
+      "owner": "pioarduino",
+      "package-version": "21.1.3+20260304",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/clangd-esp-21.1.3_20260304.zip"
+    },
     "tool-clangtidy": {
       "type": "tool",
       "optional": true,

--- a/platform.py
+++ b/platform.py
@@ -805,7 +805,7 @@ class Espressif32Platform(PlatformBase):
         Espressif's clangd has native Xtensa and ESP RISC-V support that the
         upstream clangd lacks.
         """
-        engine = os.environ.get("PLATFORMIO_IDE_INTELLISENSE_ENGINE", "")
+        engine = os.environ.get("PLATFORMIO_IDE_INTELLISENSE_ENGINE", "").strip().lower()
         if engine == "clangd" and "tool-clangd-esp" in self.packages:
             logger.info("clangd IntelliSense engine detected, installing tool-clangd-esp")
             self.install_tool("tool-clangd-esp")

--- a/platform.py
+++ b/platform.py
@@ -797,6 +797,19 @@ class Espressif32Platform(PlatformBase):
             if any(tool in package for tool in check_tools):
                 self.install_tool(package)
 
+    def _configure_clangd_tool(self) -> None:
+        """Install Espressif's clangd when the IDE has clangd IntelliSense enabled.
+
+        The pioarduino IDE extension exports PLATFORMIO_IDE_INTELLISENSE_ENGINE
+        so the platform can automatically install the matching tool package.
+        Espressif's clangd has native Xtensa and ESP RISC-V support that the
+        upstream clangd lacks.
+        """
+        engine = os.environ.get("PLATFORMIO_IDE_INTELLISENSE_ENGINE", "")
+        if engine == "clangd" and "tool-clangd-esp" in self.packages:
+            logger.info("clangd IntelliSense engine detected, installing tool-clangd-esp")
+            self.install_tool("tool-clangd-esp")
+
     def _handle_dfuutil_tool(self, variables: Dict) -> None:
         """Install dfuutil tool for Arduino Nano ESP32 board."""
         board_config = self.board_config(variables.get("board"))
@@ -851,6 +864,7 @@ class Espressif32Platform(PlatformBase):
 
             self._configure_rom_elfs_for_exception_decoder(variables)
             self._configure_check_tools(variables)
+            self._configure_clangd_tool()
             self._handle_dfuutil_tool(variables)
 
             logger.info("Package configuration completed successfully")


### PR DESCRIPTION
## Description:

install use espressif clangd when pioarduino env var intellisense is set to `clangd`.
Needs not yet released pioarduino VSC extension v1.3.8

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the clangd development tool as an optional package component.
  * Automatic provisioning of the clangd tool is now enabled when your IDE intellisense engine is configured to use clangd, streamlining the development setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->