### PR TITLE
Add support for user-specified filesystem partition

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -420,18 +420,42 @@ def fetch_fs_size(env):
     """
     Extract filesystem size and offset information from partition table.
     Sets FS_START, FS_SIZE, FS_PAGE, and FS_BLOCK environment variables.
-    
+
     Args:
         env: SCons environment object
     """
     fs = None
-    for p in _parse_partitions(env):
-        if p["type"] == "data" and p["subtype"] in (
-            "spiffs",
-            "fat",
-            "littlefs",
-        ):
-            fs = p
+    custom_fs_partition = board.get("build.filesystem_partition", "")
+
+    partitions = _parse_partitions(env)
+
+    # User-specified partition name has priority
+    if custom_fs_partition:
+        for p in partitions:
+            if p["name"] == custom_fs_partition and p["type"] == "data" and p["subtype"] in (
+                "spiffs",
+                "fat",
+                "littlefs",
+            ):
+                fs = p
+                break
+        if not fs:
+            print(
+                "Warning! Selected filesystem partition `%s` is not available in the "
+                "partition table! Default partition will be used!"
+                % custom_fs_partition
+            )
+
+    # Fallback: use last FS partition (original behavior)
+    if not fs:
+        for p in partitions:
+            if p["type"] == "data" and p["subtype"] in (
+                "spiffs",
+                "fat",
+                "littlefs",
+            ):
+                fs = p
+
     if not fs:
         sys.stderr.write(
             "Could not find the any filesystem section in the partitions "
@@ -439,7 +463,7 @@ def fetch_fs_size(env):
         )
         env.Exit(1)
         return
-    
+
     env["FS_START"] = _parse_size(fs["offset"])
     env["FS_SIZE"] = _parse_size(fs["size"])
     env["FS_PAGE"] = int("0x100", 16)

--- a/builder/main.py
+++ b/builder/main.py
@@ -426,16 +426,20 @@ def fetch_fs_size(env):
     """
     fs = None
     custom_fs_partition = board.get("build.filesystem_partition", "")
+    valid_data_types = {"data", "1", "0x01"}
+    valid_fs_subtypes = {"spiffs", "fat", "littlefs", "0x82", "0x81", "0x83"}
 
     partitions = _parse_partitions(env)
 
     # User-specified partition name has priority
     if custom_fs_partition:
         for p in partitions:
-            if p["name"] == custom_fs_partition and p["type"] == "data" and p["subtype"] in (
-                "spiffs",
-                "fat",
-                "littlefs",
+            p_type = str(p["type"]).strip().lower()
+            p_subtype = str(p["subtype"]).strip().lower()
+            if (
+                p["name"] == custom_fs_partition
+                and p_type in valid_data_types
+                and p_subtype in valid_fs_subtypes
             ):
                 fs = p
                 break
@@ -449,11 +453,9 @@ def fetch_fs_size(env):
     # Fallback: use last FS partition (original behavior)
     if not fs:
         for p in partitions:
-            if p["type"] == "data" and p["subtype"] in (
-                "spiffs",
-                "fat",
-                "littlefs",
-            ):
+            p_type = str(p["type"]).strip().lower()
+            p_subtype = str(p["subtype"]).strip().lower()
+            if p_type in valid_data_types and p_subtype in valid_fs_subtypes:
                 fs = p
 
     if not fs:

--- a/builder/main.py
+++ b/builder/main.py
@@ -110,6 +110,10 @@ SUBTYPE_SPIFFS = 0x82
 SUBTYPE_LITTLEFS = 0x83
 KNOWN_FS_SUBTYPES = (SUBTYPE_FAT, SUBTYPE_SPIFFS, SUBTYPE_LITTLEFS)
 
+# String representations for partition type matching
+VALID_DATA_TYPES = {"data", "1", "0x01"}
+VALID_FS_SUBTYPES = {"spiffs", "fat", "littlefs", "0x82", "0x81", "0x83"}
+
 
 def load_board_script(env):
     if not board_id:
@@ -426,8 +430,6 @@ def fetch_fs_size(env):
     """
     fs = None
     custom_fs_partition = board.get("build.filesystem_partition", "")
-    valid_data_types = {"data", "1", "0x01"}
-    valid_fs_subtypes = {"spiffs", "fat", "littlefs", "0x82", "0x81", "0x83"}
 
     partitions = _parse_partitions(env)
 
@@ -438,8 +440,8 @@ def fetch_fs_size(env):
             p_subtype = str(p["subtype"]).strip().lower()
             if (
                 p["name"] == custom_fs_partition
-                and p_type in valid_data_types
-                and p_subtype in valid_fs_subtypes
+                and p_type in VALID_DATA_TYPES
+                and p_subtype in VALID_FS_SUBTYPES
             ):
                 fs = p
                 break
@@ -455,7 +457,7 @@ def fetch_fs_size(env):
         for p in partitions:
             p_type = str(p["type"]).strip().lower()
             p_subtype = str(p["subtype"]).strip().lower()
-            if p_type in valid_data_types and p_subtype in valid_fs_subtypes:
+            if p_type in VALID_DATA_TYPES and p_subtype in VALID_FS_SUBTYPES:
                 fs = p
 
     if not fs:

--- a/builder/main.py
+++ b/builder/main.py
@@ -112,7 +112,7 @@ KNOWN_FS_SUBTYPES = (SUBTYPE_FAT, SUBTYPE_SPIFFS, SUBTYPE_LITTLEFS)
 
 # String representations for partition type matching
 VALID_DATA_TYPES = {"data", "1", "0x01"}
-VALID_FS_SUBTYPES = {"spiffs", "fat", "littlefs", "0x82", "0x81", "0x83"}
+VALID_FS_SUBTYPES = {"spiffs", "fat", "littlefs", hex(SUBTYPE_SPIFFS), hex(SUBTYPE_FAT), hex(SUBTYPE_LITTLEFS)}
 
 
 def load_board_script(env):

--- a/builder/main.py
+++ b/builder/main.py
@@ -452,7 +452,7 @@ def fetch_fs_size(env):
         if not fs:
             print(
                 "Warning! Selected filesystem partition `%s` is not available in the "
-                "partition table! Default partition will be used!"
+                "partition table! Falling back to last available filesystem partition."
                 % custom_fs_partition
             )
 

--- a/builder/main.py
+++ b/builder/main.py
@@ -112,7 +112,11 @@ KNOWN_FS_SUBTYPES = (SUBTYPE_FAT, SUBTYPE_SPIFFS, SUBTYPE_LITTLEFS)
 
 # String representations for partition type matching
 VALID_DATA_TYPES = {"data", "1", "0x01"}
-VALID_FS_SUBTYPES = {"spiffs", "fat", "littlefs", hex(SUBTYPE_SPIFFS), hex(SUBTYPE_FAT), hex(SUBTYPE_LITTLEFS)}
+VALID_FS_SUBTYPES = {
+    "spiffs", "fat", "littlefs",
+    hex(SUBTYPE_SPIFFS), hex(SUBTYPE_FAT), hex(SUBTYPE_LITTLEFS),
+    str(SUBTYPE_SPIFFS), str(SUBTYPE_FAT), str(SUBTYPE_LITTLEFS)
+}
 
 
 def load_board_script(env):

--- a/docs/FILESYSTEM_PARTITION_SELECTION.md
+++ b/docs/FILESYSTEM_PARTITION_SELECTION.md
@@ -1,0 +1,52 @@
+# Filesystem Partition Selection in pioarduino
+
+## Overview
+
+pioarduino ESP32 platform now supports explicit filesystem partition selection via `board_build.filesystem_partition` option. This allows targeting specific filesystem partitions when multiple partitions are present in the partition table.
+
+## Configuration
+
+Add the following option to your `platformio.ini`:
+
+```ini
+[env:esp32s3]
+# ... other settings ...
+board_build.filesystem_partition = spiffs1
+```
+
+## Supported Partition Types
+
+The system recognizes both string and numeric partition types:
+
+### Data Partition Types
+- `"data"` - String representation
+- `"1"` - Decimal representation  
+- `"0x01"` - Hexadecimal representation
+
+### Filesystem Subtypes
+- `"spiffs"`, `"fat"`, `"littlefs"` - String representations
+- `"0x82"`, `"0x81"`, `"0x83"` - Hexadecimal representations
+- `"130"`, `"129"`, `"131"` - Decimal representations (via `str()` conversion)
+
+## Behavior
+
+1. **Priority**: If `board_build.filesystem_partition` is specified, the system first looks for a partition with that exact name
+2. **Fallback**: If the named partition is not found or not specified, the system falls back to the last available filesystem partition (original behavior)
+3. **Warning**: When a named partition is specified but not found, a warning is displayed before fallback
+
+## Example Partition Table
+
+```csv
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+spiffs1,  data, spiffs,  0xC0000, 0x100000,
+spiffs2,  data, spiffs,  0x1C0000,0x200000,
+```
+
+With `board_build.filesystem_partition = spiffs1`:
+- Upload targets partition at offset `0xC0000`
+- If `spiffs1` doesn't exist, falls back to `spiffs2`
+
+## Backward Compatibility
+
+Existing projects without `board_build.filesystem_partition` continue to work unchanged - they will use the last filesystem partition as before.


### PR DESCRIPTION


## Description:

### How it works
Users can now specify the target filesystem partition in `platformio.ini`:
```ini
board_build.filesystem_partition = my_storage
```

This maps to `board.get("build.filesystem_partition", "")` in `fetch_fs_size()`.

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Boards can now specify a filesystem partition by name in configuration; the build will prefer that partition when valid.
  * Recognizes common filesystem types (SPIFFS/FAT/LittleFS) when selecting partitions.
  * If no named partition is set or matches, it falls back to automatic detection.
  * Clear build failure occurs when no suitable filesystem partition is found.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pioarduino/platform-espressif32/pull/491)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->