### PR TITLE
refactor esptool installation command to use --reinstall-package option

### DIFF
--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -582,7 +582,8 @@ def install_esptool(env, platform, python_exe, uv_executable, uv_cache_dir=None)
 
     try:
         subprocess.check_call([
-            uv_executable, "pip", "install", "--quiet", "--force-reinstall",
+            uv_executable, "pip", "install", "--quiet",
+            "--reinstall-package", "esptool",
             f"--python={python_exe}",
             "-e", esptool_repo_path
         ], timeout=60, env=uv_env)
@@ -808,7 +809,8 @@ def _install_esptool_from_tl_install(platform, python_exe, uv_executable, uv_cac
 
     try:
         subprocess.check_call([
-            uv_executable, "pip", "install", "--quiet", "--force-reinstall",
+            uv_executable, "pip", "install", "--quiet",
+            "--reinstall-package", "esptool",
             f"--python={python_exe}",
             "-e", esptool_repo_path
         ], timeout=60, env=uv_env)


### PR DESCRIPTION
## Description:

This pull request updates the way `esptool` is reinstalled in the `builder/penv_setup.py` script. Replacing the `--force-reinstall` flag with the new `--reinstall-package` flag when using `uv pip install` for `esptool`.

Meshtastic uses custom builder images (wrapped in a GitHub Action) for each platform we support (esp32, esp32s3, nrf52840, etc) [meshtastic/gh-action-firmware](https://github.com/meshtastic/gh-action-firmware). These images are pre-seeded for each platformio environment (board) we support by looping through running `pio pkg install -e <variant>`.
On each firmware *build* (run within the pre-seeded containers), we are seeing a mismatch during the esptoolpy install.
```
Expected: /pio/core/packages/tool-esptoolpy
Actual: /pio/core/penv/lib/python3.13/site-packages/esptool
```
Because of that mismatch, platform-espressif's penv setup will try to uv `--force-reinstall` a new one.

`uv pip install --force-reinstall` implies a `--refresh` and disregards cache, causing the Meshtastic build runners to timeout at this step (likely pypi rate limiting?). `--reinstall-package esptool` does not, while still accomplishing the goal of reinstalling esptool directly from the tool package.

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the esptool installation process to ensure the intended package is reinstalled reliably.
  * Applied consistent reinstall behavior across supported installation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->