### PR TITLE
fix: resolve flash_extra_images paths from Arduino framework dir, not hardcoded Tasmota path

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -3165,7 +3165,7 @@ if ota_partition_params["size"] and ota_partition_params["offset"]:
     )
     extra_imgs = board.get("upload.arduino.flash_extra_images", [])
     if extra_imgs:
-        extra_img_dir = Path(env.subst("$PROJECT_DIR")) / "variants" / "tasmota"
+        extra_img_dir = Path(ARDUINO_FRAMEWORK_DIR)
         env.Append(
              FLASH_EXTRA_IMAGES=[(offset, str(extra_img_dir / img)) for offset, img in extra_imgs]
         )


### PR DESCRIPTION
Fixes #517.

### Problem

In hybrid `arduino + espidf` builds, `flash_extra_images` paths from board JSON definitions are resolved relative to a hardcoded `$PROJECT_DIR/variants/tasmota/` directory (espidf.py L3168). This produces broken paths for all boards that use `flash_extra_images`, because the board JSON paths are relative to the Arduino framework package, not the project directory.

Example broken path:
```
<project>/variants/tasmota/variants/arduino_nano_nora/extra/nora_recovery/nora_recovery.ino.bin
```

### Fix

Resolve `flash_extra_images` relative to `ARDUINO_FRAMEWORK_DIR` — the same variable already used to resolve `boot_app0.bin` at line 3152. Single-line change.

```diff
-        extra_img_dir = Path(env.subst("$PROJECT_DIR")) / "variants" / "tasmota"
+        extra_img_dir = Path(ARDUINO_FRAMEWORK_DIR)
```

### Impact

- **Fixes**: 17 boards that define `flash_extra_images` in their board JSON — Arduino Nano ESP32 (`nora_recovery.ino.bin`), 12 Adafruit boards (`tinyuf2.bin`), Cytron, RedPill, SenseBox, Feather ESP32-S2
- **No impact on Tasmota**: Tasmota sets `FLASH_EXTRA_IMAGES` via its own `pio-tools/post_esp32.py` post-build script, not through board JSON `flash_extra_images`

### Verification

Tested with `board = arduino_nano_esp32` and `framework = arduino, espidf` — confirmed `firmware.factory.bin` merge now succeeds with `nora_recovery.ino.bin` correctly resolved from the framework package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Arduino extra flash images so they are correctly located relative to the Arduino framework directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->