### PR TITLE
fix(espidf): deduplicate bootloader LINKFLAGS to prevent fatal error with binutils >= 2.40

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2085,6 +2085,29 @@ def build_bootloader(sdk_config):
             i += 1
     
     bootloader_env.Append(LINKFLAGS=processed_extra_flags)
+
+    # Deduplicate LINKFLAGS to prevent "linker script appears multiple times"
+    # error with binutils >= 2.40. The -T flags can arrive via both
+    # INTERFACE_LINK_LIBRARIES (merged at MergeFlags above) and
+    # processed_extra_flags (appended here).
+    # Note: -T and -u are two-token flags (-T <script>, -u <symbol>),
+    # so we must deduplicate them as pairs, not as individual tokens.
+    seen_pairs = set()
+    deduped = []
+    linkflags = list(bootloader_env["LINKFLAGS"])
+    i = 0
+    while i < len(linkflags):
+        if linkflags[i] in ("-T", "-u") and i + 1 < len(linkflags):
+            pair = (linkflags[i], linkflags[i + 1])
+            if pair not in seen_pairs:
+                seen_pairs.add(pair)
+                deduped.extend([linkflags[i], linkflags[i + 1]])
+            i += 2
+        else:
+            deduped.append(linkflags[i])
+            i += 1
+    bootloader_env.Replace(LINKFLAGS=deduped)
+
     bootloader_libs = find_lib_deps(components_map, elf_config, link_args)
 
     bootloader_env.Prepend(__RPATH="-Wl,--start-group ")
@@ -2896,6 +2919,28 @@ env.Prepend(
         ),
     ],
 )
+
+# Deduplicate LINKFLAGS to prevent "linker script appears multiple times"
+# error with binutils >= 2.40. The -T flags can arrive via both
+# INTERFACE_LINK_LIBRARIES (merged at MergeFlags above) and
+# extra_flags (prepended here).
+# Note: -T and -u are two-token flags (-T <script>, -u <symbol>),
+# so we must deduplicate them as pairs, not as individual tokens.
+seen_pairs = set()
+deduped = []
+linkflags = list(env["LINKFLAGS"])
+i = 0
+while i < len(linkflags):
+    if linkflags[i] in ("-T", "-u") and i + 1 < len(linkflags):
+        pair = (linkflags[i], linkflags[i + 1])
+        if pair not in seen_pairs:
+            seen_pairs.add(pair)
+            deduped.extend([linkflags[i], linkflags[i + 1]])
+        i += 2
+    else:
+        deduped.append(linkflags[i])
+        i += 1
+env.Replace(LINKFLAGS=deduped)
 
 #
 # Propagate Arduino defines to the main build environment


### PR DESCRIPTION
## Problem

Building ESP32 (original Xtensa) targets with `toolchain-xtensa-esp-elf @ 14.2.0` fails at both bootloader and firmware linking:

```
ld: error: linker script file 'esp32.rom.libc-funcs.ld' appears multiple times
```

The same `-T` linker script flag enters `LINKFLAGS` via two independent paths in **two code locations**:

1. **Bootloader**: `bootloader_env.MergeFlags(link_args)` at L2011 + `bootloader_env.Append(LINKFLAGS=processed_extra_flags)` at L2087
2. **Main firmware**: `env.MergeFlags(link_args)` at L2901 + `env.Prepend(LINKFLAGS=extra_flags)` at L2906

In both cases, `MergeFlags()` injects `-T` flags via `INTERFACE_LINK_LIBRARIES` from the CMake code model, then the explicit append/prepend re-adds them.

Binutils < 2.40 silently ignored duplicate `-T` flags; binutils ≥ 2.40 (shipped with GCC 14.2.0) treats them as a fatal error.

## Fix

Add pair-aware LINKFLAGS deduplication after both merge+append sites. Since `-T` and `-u` are two-token flags (`-T <script>`, `-u <symbol>`), the deduplication operates on `(flag, argument)` pairs rather than individual tokens. This is a no-op when no duplicates exist and is safe for all targets.

## Testing

- ✅ `esp32dev` full app build — bootloader + firmware link and build successfully
- ✅ `bootloader.bin` and `firmware.bin` both generated correctly
- ✅ Flag ordering preserved — non-paired flags pass through unchanged
- ✅ No regression for ESP32-S3/P4 (no duplicates to remove, list unchanged)

Fixes #519
