### PR TITLE
fix: add_lto_flags to prevent full rebuilds

### DIFF
--- a/builder/frameworks/component_manager.py
+++ b/builder/frameworks/component_manager.py
@@ -1463,6 +1463,9 @@ class ComponentManager:
             with open(build_py_path, 'r', encoding='utf-8') as f:
                 content = f.read()
 
+            if '"-flto=auto",' in content:
+                return True
+
             modified = False
 
             # Add -flto=auto to CCFLAGS right after the opening bracket


### PR DESCRIPTION
## Description:

When using `'-fno-lto' `in `build_unflags` the script `component_manager.py` unconditionally adds `-flto=auto` to the `pioarduino-build.py` file. With every build the compiler argument list changes which causes successive rebuilds of the entire project:
<img width="1312" height="166" alt="Screenshot from 2026-08-16 22-45-33" src="https://github.com/user-attachments/assets/6cda35bd-8f39-46a7-ae02-18bd54a92944" />

This PR adds a check if `-flto=auto` is already present and skips further adding.

## Checklist:
  - [x] The pull request is done against the latest develop branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR, more changes are allowed when changing boards.json
  - [x] I accept the [CLA](https://github.com/pioarduino/platform-espressif32/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate link-time optimization flags from being added during builds.
  * Preserved existing flag handling and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->