### PR TITLE
fix: actually reinstall a tool after a version mismatch instead of silently doing nothing

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -620,8 +620,11 @@ class Espressif32Platform(PlatformBase):
         safe_remove_directory(paths['tool_path'])
 
         # Re-fetch the source package so tools.json is available again and
-        # install_tool() can take the idf_tools.py installation path.
-        if isinstance(source_spec, str) and source_spec.startswith(("http://", "https://")):
+        # install_tool() can take the idf_tools.py installation path. Only
+        # https:// is accepted, matching every source in platform.json today —
+        # this avoids ever fetching a package over plaintext http:// even if a
+        # future/custom platform.json entry specified one.
+        if isinstance(source_spec, str) and source_spec.startswith("https://"):
             try:
                 pm.install(source_spec)
             except Exception:

--- a/platform.py
+++ b/platform.py
@@ -567,6 +567,13 @@ class Espressif32Platform(PlatformBase):
                 not status['has_tools_json']):
             return self._handle_existing_tool(tool_name, paths)
 
+        if not status['tool_exists']:
+            logger.warning(
+                f"{tool_name} is not present in {self.packages_dir} and no local "
+                f"installation source is available (no tools.json, no .piopm); "
+                f"relying on PlatformIO to fetch it from platform.json"
+            )
+
         logger.debug(f"Tool {tool_name} already configured")
         return True
 
@@ -603,8 +610,25 @@ class Espressif32Platform(PlatformBase):
         # Version mismatch detected, reinstall tool (cleanup already performed)
         logger.info(f"Reinstalling {tool_name} due to version mismatch")
 
+        # Remember the installation source from platform.json before deleting
+        # anything. The directory removed below holds the only local copy of
+        # tools.json; without it the install_tool() call at the end of this
+        # method matches no branch and returns success having installed nothing.
+        source_spec = self.packages[tool_name].get("version")
+
         # Remove the main tool directory (if it still exists after cleanup)
         safe_remove_directory(paths['tool_path'])
+
+        # Re-fetch the source package so tools.json is available again and
+        # install_tool() can take the idf_tools.py installation path.
+        if isinstance(source_spec, str) and source_spec.startswith(("http://", "https://")):
+            try:
+                pm.install(source_spec)
+            except Exception:
+                logger.exception(
+                    f"Failed to re-fetch installation source for {tool_name}"
+                )
+                return False
 
         return self.install_tool(tool_name)
 

--- a/platform.py
+++ b/platform.py
@@ -269,6 +269,7 @@ class Espressif32Platform(PlatformBase):
         self._packages_dir = None
         self._tools_cache = {}
         self._mcu_config_cache = {}
+        self._tool_sources = {}
 
     @property
     def packages_dir(self) -> Path:
@@ -552,6 +553,15 @@ class Espressif32Platform(PlatformBase):
     def install_tool(self, tool_name: str) -> bool:
         """Install a tool."""
         self.packages[tool_name]["optional"] = False
+        # Remember platform.json's original source the first time this tool is
+        # seen. _handle_existing_tool()'s version-match branch later repoints
+        # self.packages[tool_name]["version"] at a local path; without this
+        # cache, a second install_tool() call for the same tool within this
+        # platform instance's lifetime (e.g. a package required by both
+        # _configure_mcu_toolchains() and _configure_rom_elfs_for_exception_decoder())
+        # would read that local path as its mismatch-recovery source instead
+        # of the real download URL.
+        self._tool_sources.setdefault(tool_name, self.packages[tool_name].get("version"))
         paths = self._get_tool_paths(tool_name)
         status = self._check_tool_status(tool_name)
 
@@ -610,11 +620,15 @@ class Espressif32Platform(PlatformBase):
         # Version mismatch detected, reinstall tool (cleanup already performed)
         logger.info(f"Reinstalling {tool_name} due to version mismatch")
 
-        # Remember the installation source from platform.json before deleting
-        # anything. The directory removed below holds the only local copy of
-        # tools.json; without it the install_tool() call at the end of this
-        # method matches no branch and returns success having installed nothing.
-        source_spec = self.packages[tool_name].get("version")
+        # Use the source cached on first sight by install_tool(), not
+        # self.packages[tool_name]["version"] directly — the match branch
+        # above may have already repointed that field at a local path on an
+        # earlier call for this same tool within this platform instance's
+        # lifetime. The directory removed below holds the only local copy of
+        # tools.json; without a real URL here, the install_tool() call at the
+        # end of this method matches no branch and returns success having
+        # installed nothing.
+        source_spec = self._tool_sources.get(tool_name)
 
         # Remove the main tool directory (if it still exists after cleanup)
         safe_remove_directory(paths['tool_path'])

--- a/test/test_tool_reinstall.py
+++ b/test/test_tool_reinstall.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Regression tests for the toolchain-wipe fix in platform.py.
+
+Covers two scenarios in Espressif32Platform.install_tool() /
+_handle_existing_tool():
+
+1. A version mismatch must actually trigger a reinstall (the tool is not
+   left as a bare registry stub after install_tool() returns True).
+2. Calling install_tool() twice for the same tool within one platform
+   instance's lifetime must not lose the original platform.json source.
+   The version-match branch repoints self.packages[tool_name]["version"]
+   at a local path; without caching the original source on first sight,
+   a later mismatch for that same tool reads the local path instead of a
+   real URL and silently skips reinstalling it (github.com/pioarduino/
+   platform-espressif32/pull/527).
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+from unittest import mock
+
+# Pre-cache the real stdlib "platform" module before loading platform.py by
+# path below. The repo root (which contains a file literally named
+# platform.py) ends up on sys.path when tests run via `python -m unittest`,
+# so anything that later does `import platform` (e.g. pyserial's miniterm,
+# imported transitively through platformio.public) would otherwise resolve
+# to this project's platform.py instead of the stdlib module.
+import platform  # noqa: F401
+
+PLATFORM_PY = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "platform.py")
+
+
+def load_platform_module():
+    # platform.py shares its name with the stdlib "platform" module, so it's
+    # loaded under a distinct module name rather than via a plain import -
+    # the same approach platformio.platform.factory.PlatformFactory uses.
+    spec = importlib.util.spec_from_file_location("espressif32_platform_under_test", PLATFORM_PY)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ToolReinstallTestCase(unittest.TestCase):
+    """Base fixture: a bare Espressif32Platform instance with mocked collaborators."""
+
+    def setUp(self):
+        self.platform_module = load_platform_module()
+
+        # PlatformBase.__init__ needs a real platform.json + ProjectConfig,
+        # which this test has no interest in exercising - bypass it and set
+        # up just the state install_tool()/_handle_existing_tool() touch.
+        self.platform = object.__new__(self.platform_module.Espressif32Platform)
+        self.platform._packages_dir = "/fake/packages"
+        self.platform._tools_cache = {}
+        self.platform._mcu_config_cache = {}
+        self.platform._tool_sources = {}
+        self.platform._penv_python = None
+        self.platform._manifest = {
+            "packages": {
+                "toolchain-xtensa-esp-elf": {
+                    "type": "toolchain",
+                    "optional": True,
+                    "owner": "pioarduino",
+                    "package-version": "14.2.0+20260121",
+                    "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/xtensa-esp-elf-14.2.0_20260121.zip",
+                }
+            }
+        }
+        self.platform._custom_packages = None
+
+        self.pm_install_patcher = mock.patch.object(self.platform_module, "pm")
+        self.mock_pm = self.pm_install_patcher.start()
+        self.addCleanup(self.pm_install_patcher.stop)
+
+        self.remove_dir_patcher = mock.patch.object(self.platform_module, "safe_remove_directory")
+        self.mock_remove_dir = self.remove_dir_patcher.start()
+        self.addCleanup(self.remove_dir_patcher.stop)
+
+        paths_patcher = mock.patch.object(
+            self.platform_module.Espressif32Platform, "_get_tool_paths",
+            return_value={
+                "tool_path": "/fake/packages/toolchain-xtensa-esp-elf",
+                "tools_json_path": "/fake/packages/toolchain-xtensa-esp-elf/tools.json",
+                "idf_tools_path": "/fake/tools/idf_tools.py",
+                "package_path": "/fake/packages/toolchain-xtensa-esp-elf/package.json",
+            },
+        )
+        paths_patcher.start()
+        self.addCleanup(paths_patcher.stop)
+
+    def set_tool_status(self, **overrides):
+        status = {
+            "has_idf_tools": True,
+            "has_tools_json": False,
+            "has_piopm": True,
+            "tool_exists": True,
+        }
+        status.update(overrides)
+        patcher = mock.patch.object(
+            self.platform_module.Espressif32Platform, "_check_tool_status", return_value=status
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def set_version_check(self, matches):
+        patcher = mock.patch.object(
+            self.platform_module.Espressif32Platform, "_check_tool_version", return_value=matches
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+
+class TestMismatchTriggersReinstall(ToolReinstallTestCase):
+    """A version mismatch must re-fetch the real source, not fall through silently."""
+
+    def test_mismatch_refetches_https_source_before_recursing(self):
+        self.set_tool_status()
+        self.set_version_check(matches=False)
+        # Populate the cache the way a real install_tool() call would,
+        # without going through install_tool() itself - the routing between
+        # Case 1/Case 2/fall-through in install_tool() is not what this
+        # test is exercising, only _handle_existing_tool()'s mismatch branch.
+        self.platform._tool_sources["toolchain-xtensa-esp-elf"] = (
+            self.platform.packages["toolchain-xtensa-esp-elf"]["version"]
+        )
+        paths = self.platform_module.Espressif32Platform._get_tool_paths(
+            self.platform, "toolchain-xtensa-esp-elf"
+        )
+
+        # install_tool()'s own recursive call at the end of
+        # _handle_existing_tool() (after the re-fetch) is not under test
+        # here - stub it so this test stays focused on whether the re-fetch
+        # itself happens, with the right source, before that recursion.
+        with mock.patch.object(
+            self.platform_module.Espressif32Platform, "install_tool", return_value=True
+        ):
+            result = self.platform_module.Espressif32Platform._handle_existing_tool(
+                self.platform, "toolchain-xtensa-esp-elf", paths
+            )
+
+        self.assertTrue(result)
+        self.mock_pm.install.assert_called_once_with(
+            "https://github.com/pioarduino/registry/releases/download/0.0.1/xtensa-esp-elf-14.2.0_20260121.zip"
+        )
+        self.mock_remove_dir.assert_called_once_with("/fake/packages/toolchain-xtensa-esp-elf")
+
+
+class TestSecondMismatchAfterEarlierMatch(ToolReinstallTestCase):
+    """
+    Reproduces the scenario from the PR #527 review comment: a package that
+    is install_tool()'d twice in one platform instance's lifetime (e.g.
+    required by both _configure_mcu_toolchains() and
+    _configure_rom_elfs_for_exception_decoder() for tool-esp-rom-elfs) must
+    not lose its real source on the second call just because the first call
+    took the version-match branch and repointed "version" at a local path.
+    """
+
+    def test_original_source_survives_an_intervening_match(self):
+        self.set_tool_status()
+
+        original_source = self.platform.packages["toolchain-xtensa-esp-elf"]["version"]
+
+        # First call: version matches. This mutates
+        # self.packages[tool_name]["version"] to a local path, per the
+        # existing (unmodified) behavior in _handle_existing_tool().
+        self.set_version_check(matches=True)
+        first_result = self.platform_module.Espressif32Platform.install_tool(
+            self.platform, "toolchain-xtensa-esp-elf"
+        )
+        self.assertTrue(first_result)
+        self.assertNotEqual(
+            self.platform.packages["toolchain-xtensa-esp-elf"]["version"], original_source
+        )
+
+        # Second call, same instance: version now mismatches (e.g. the
+        # install got corrupted between checks). The recovery path must
+        # still re-fetch the *original* https:// source, not the local
+        # path the first call left behind.
+        self.set_version_check(matches=False)
+        with mock.patch.object(
+            self.platform_module.Espressif32Platform, "install_tool",
+            side_effect=[None, True],
+        ):
+            self.platform_module.Espressif32Platform._handle_existing_tool(
+                self.platform,
+                "toolchain-xtensa-esp-elf",
+                self.platform_module.Espressif32Platform._get_tool_paths(self.platform, "toolchain-xtensa-esp-elf"),
+            )
+
+        self.mock_pm.install.assert_called_once_with(original_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_tool_reinstall.py
+++ b/test/test_tool_reinstall.py
@@ -19,16 +19,30 @@ _handle_existing_tool():
 import importlib.util
 import os
 import sys
+import sysconfig
 import unittest
 from unittest import mock
 
-# Pre-cache the real stdlib "platform" module before loading platform.py by
-# path below. The repo root (which contains a file literally named
-# platform.py) ends up on sys.path when tests run via `python -m unittest`,
-# so anything that later does `import platform` (e.g. pyserial's miniterm,
-# imported transitively through platformio.public) would otherwise resolve
-# to this project's platform.py instead of the stdlib module.
-import platform  # noqa: F401
+
+def _load_real_stdlib_platform_module():
+    # The repo root (which contains a file literally named platform.py) ends
+    # up on sys.path when tests run via `python -m unittest`, ahead of the
+    # real standard library directory. A plain `import platform` here would
+    # therefore be order-dependent - it only resolves correctly if something
+    # else already imported the real module first. Load it deterministically
+    # by its known path instead, bypassing sys.path search entirely, so
+    # anything that later does `import platform` (e.g. pyserial's miniterm,
+    # imported transitively through platformio.public) gets the genuine
+    # standard library module regardless of import order.
+    stdlib_path = os.path.join(sysconfig.get_path("stdlib"), "platform.py")
+    spec = importlib.util.spec_from_file_location("platform", stdlib_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["platform"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_load_real_stdlib_platform_module()
 
 PLATFORM_PY = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "platform.py")
 


### PR DESCRIPTION
Fixes #526

## Description

`_handle_existing_tool()` handles a version mismatch by deleting the tool directory and recursing into `install_tool()`. The deleted directory was the only local copy of `tools.json`, which is the file that selects `install_tool()`'s idf_tools.py branch. On the recursive call, `has_tools_json`, `has_piopm` and `tool_exists` are all `False`, so no branch matches and the function logs `"Tool ... already configured"` and returns `True` without installing anything.

For `toolchain-xtensa-esp-elf` the visible result is a destroyed toolchain: the package entry is still non-optional, so PlatformIO refetches `platform.json`'s `version` URL, which for this package is a 1601-byte manifest stub rather than the compiler. The user gets a package directory with a plausible `package.json` and no `bin/`, and a build that cannot find `xtensa-esp32s3-elf-g++`. On the next run `tools.json` is present again, so the full ~414 MB toolchain is re-downloaded — and if the mismatch condition recurs, so does the wipe.

This change makes the mismatch path re-fetch the installation source (the `platform.json` URL) before recursing, so `install_tool()` finds `tools.json` and takes the real installation path. It also adds a warning on the fall-through branch, which previously reported success for a tool that is not on disk.

### Why it is safe

- The re-fetch reuses `pm.install(...)`, the same call `_install_tl_install()` already uses at `platform.py:399`, with `pm` being the module-level `ToolPackageManager()` from `platform.py:131`.
- `self.packages[tool_name]["version"]` is only rewritten to a local path on the *matching* branch (`platform.py:598`); on the mismatch branch it is still the `platform.json` source spec, so this is the correct value to reinstall from.
- The URL guard means the behaviour is unchanged for any package whose `version` is already a local path or a plain version string.
- No new recursion depth: the recursive `install_tool()` now reaches Case 1 (`_install_with_idf_tools`), which does not call back into `_handle_existing_tool()`.
- The second hunk is diagnostic only — it does not change the return value, so first-run ordering (where a package legitimately is not yet on disk when `configure_default_packages()` runs) still behaves exactly as before.

### Testing performed

Applied verbatim to an isolated `platform.py` (real platform release, real project config, `PLATFORMIO_CORE_DIR` redirected so nothing touched a real install), then re-ran the version-mismatch repro (`"version": "14.2.0_20260121"` injected into a fresh `toolchain-xtensa-esp-elf` install).

**Confirmed fixed:** the `"already configured"` fall-through no longer fires. `pm.install()` (hunk 2) refetches the source spec, and the recursive `install_tool()` call now reaches `_install_with_idf_tools()` and downloads the real ~414 MB crosstool-NG archive, instead of returning `True` for a deleted package:

```
Version mismatch for toolchain-xtensa-esp-elf: 14.2.0_20260121 != 14.2.0+20260121
Reinstalling toolchain-xtensa-esp-elf due to version mismatch
Directory removed: ...\packages\toolchain-xtensa-esp-elf
Tool Manager: toolchain-xtensa-esp-elf@14.2.0+20260121 has been installed!      <- was "already configured" before the patch
Installing tools via idf_tools.py (this may take several minutes)...
```

Hunk 1's warning was also confirmed to fire correctly for a package genuinely absent from disk (`contrib-piohome is not present in ... and no local installation source is available`).

**Not confirmed — environmental failure, not caused by this patch:** on this test machine, `idf_tools.py` itself then failed in `do_strip_container_dirs` with `PermissionError: [WinError 5] Access is denied` renaming the just-written 1.4 GB directory. This happened identically on an *unpatched* run reproducing the same trigger, so it's unrelated to this change (a plain `os.rename` of a freshly created directory succeeds on the same filesystem — looks like an AV/indexer handle on the just-written tree, not a `subst`/path artifact). A maintainer on a machine where `idf_tools.py` completes cleanly should confirm the toolchain is fully usable after this patch, not just that it starts reinstalling.

All packages in `platform.json` use `https://` `version` specs, so hunk 2's URL guard (`source_spec.startswith(("http://", "https://"))`) applies uniformly — this isn't a partial fix limited to some packages.

### Related, out of scope for this patch

Testing this patch also surfaced a second, independent silent-success path: after the `WinError 5` above, a subsequent run had `idf_tools.py` treat the half-stripped tool as already installed and exit 0, so `_install_with_idf_tools()` logged `"Tool ... successfully installed"` for a tree with no `bin/`. Nothing validates the installed tool actually contains its expected binaries. Worth a follow-up (post-install sanity check), not bundled into this patch.

---

## Diff

```diff
--- a/platform.py
+++ b/platform.py
@@ -565,7 +565,14 @@ class Espressif32Platform(PlatformBase):
         # Case 2: Tool already installed, perform version validation
         if (status['has_idf_tools'] and status['has_piopm'] and
                 not status['has_tools_json']):
             return self._handle_existing_tool(tool_name, paths)
 
+        if not status['tool_exists']:
+            logger.warning(
+                f"{tool_name} is not present in {self.packages_dir} and no local "
+                f"installation source is available (no tools.json, no .piopm); "
+                f"relying on PlatformIO to fetch it from platform.json"
+            )
+
         logger.debug(f"Tool {tool_name} already configured")
         return True
 
@@ -600,10 +607,27 @@ class Espressif32Platform(PlatformBase):
             logger.debug(f"Tool {tool_name} found with correct version")
             return True
 
         # Version mismatch detected, reinstall tool (cleanup already performed)
         logger.info(f"Reinstalling {tool_name} due to version mismatch")
 
+        # Remember the installation source from platform.json before deleting
+        # anything. The directory removed below holds the only local copy of
+        # tools.json; without it the install_tool() call at the end of this
+        # method matches no branch and returns success having installed nothing.
+        source_spec = self.packages[tool_name].get("version")
+
         # Remove the main tool directory (if it still exists after cleanup)
         safe_remove_directory(paths['tool_path'])
 
+        # Re-fetch the source package so tools.json is available again and
+        # install_tool() can take the idf_tools.py installation path.
+        if isinstance(source_spec, str) and source_spec.startswith(("http://", "https://")):
+            try:
+                pm.install(source_spec)
+            except Exception:
+                logger.exception(
+                    f"Failed to re-fetch installation source for {tool_name}"
+                )
+                return False
+
         return self.install_tool(tool_name)
```

---

## Optional follow-up (not in this patch)

`_install_with_idf_tools()` (`platform.py:581-583`) writes the authoritative `package.json` to `<IDF_TOOLS_PATH>/tools/<tool_name>/package.json`, which is the same path the extracted crosstool-NG archive's own `package.json` lands at (its `tools.json` sets `"strip_container_dirs": 1`). That archive file reads `"name": "xtensa-esp-elf", "version": "14.2.0_20260121"` — underscore — against the `"package-version": "14.2.0+20260121"` required at `platform.json:66`. The correct metadata therefore survives only because the copy overwrites the archive's file. Either writing that metadata to a name idf_tools.py cannot produce, or normalizing `+` vs `_` before the date suffix in `_check_tool_version()` (`platform.py:539`), would remove the dependency on that overwrite. Worth a separate PR after maintainer input on which they prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool reinstallation after version mismatches by reliably retrieving packages from their original secure source.
  * Fixed repeated installations so tools continue using the correct package source instead of an accidentally redirected local path.
  * Improved recovery when required packages are unavailable locally, including clearer warnings and safer handling of remote package retrieval.
  * Prevented stale tool contents from remaining after a version mismatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->